### PR TITLE
feat(php): update deprecation version number in `semantic-release` run

### DIFF
--- a/ssf/files/tofs_php-formula/pre-commit_semantic-release.sh
+++ b/ssf/files/tofs_php-formula/pre-commit_semantic-release.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+###############################################################################
+# (A) Update `FORMULA` with `${nextRelease.version}`
+###############################################################################
+sed -i -e "s_^\(version:\).*_\1 ${1}_" FORMULA
+
+
+###############################################################################
+# (B) Use `m2r` to convert automatically produced `.md` docs to `.rst`
+###############################################################################
+
+# Install `m2r`
+sudo -H pip install m2r
+
+# Copy and then convert the `.md` docs
+cp *.md docs/
+cd docs/
+m2r --overwrite *.md
+
+# Change excess `H1` headings to `H2` in converted `CHANGELOG.rst`
+sed -i -e '/^=.*$/s/=/-/g' CHANGELOG.rst
+sed -i -e '1,4s/-/=/g' CHANGELOG.rst
+
+# Use for debugging output, when required
+# cat AUTHORS.rst
+# cat CHANGELOG.rst
+
+# Return back to the main directory
+cd ..
+
+
+###############################################################################
+# (C) Update last version before `v1.0.0` with `${nextRelease.version}`
+###############################################################################
+# Only apply this while the version number is below `v1.0.0`!
+V_REPR=v${1}
+MAJOR=$(echo ${V_REPR} | cut -c-2)
+if [ ${MAJOR} = "v0" ]; then
+    sed -i -e "s@^\(\s\+\`\).*\(\s<https://github.com/saltstack-formulas/php-formula/releases/tag/\).*\(>\`_\.\)@\1${V_REPR}\2${V_REPR}\3@" docs/README.rst
+    sed -i -e "s@^\(\s\+# the final release tag before \`v1.0.0\`, which is expected to be \`\).*\(\`.\s\+#\)@\1${V_REPR}\2@" php/deprecated.sls
+    sed -i -e "s@^\(\s\+# the final release tag before \`v1.0.0\`, which is expected to be \`\).*\(\`.\s\+#\)@\1${V_REPR}\2@" php/ng/deprecated.sls
+fi

--- a/ssf/files/tofs_php-formula/release.config.js
+++ b/ssf/files/tofs_php-formula/release.config.js
@@ -1,0 +1,106 @@
+module.exports = {
+  branch: 'master',
+  plugins: [
+      ['@semantic-release/commit-analyzer', {
+        preset: 'angular',
+        releaseRules: './release-rules.js',
+      }],
+      '@semantic-release/release-notes-generator',
+      ['@semantic-release/changelog', {
+        changelogFile: 'CHANGELOG.md',
+        changelogTitle: '# Changelog',
+      }],
+      ['@semantic-release/exec', {
+        prepareCmd: 'sh ./pre-commit_semantic-release.sh ${nextRelease.version}',
+      }],
+      ['@semantic-release/git', {
+        assets: ['*.md', 'docs/*.rst', 'FORMULA', 'php/deprecated.sls', 'php/ng/deprecated.sls'],
+      }],
+      '@semantic-release/github',
+  ],
+  generateNotes: {
+    preset: 'angular',
+    writerOpts: {
+      // Required due to upstream bug preventing all types being displayed.
+      // Bug: https://github.com/conventional-changelog/conventional-changelog/issues/317
+      // Fix: https://github.com/conventional-changelog/conventional-changelog/pull/410
+      transform: (commit, context) => {
+          const issues = []
+
+          commit.notes.forEach(note => {
+              note.title = `BREAKING CHANGES`
+          })
+
+          // NOTE: Any changes here must be reflected in `CONTRIBUTING.md`.
+          if (commit.type === `feat`) {
+              commit.type = `Features`
+          } else if (commit.type === `fix`) {
+              commit.type = `Bug Fixes`
+          } else if (commit.type === `perf`) {
+              commit.type = `Performance Improvements`
+          } else if (commit.type === `revert`) {
+              commit.type = `Reverts`
+          } else if (commit.type === `docs`) {
+              commit.type = `Documentation`
+          } else if (commit.type === `style`) {
+              commit.type = `Styles`
+          } else if (commit.type === `refactor`) {
+              commit.type = `Code Refactoring`
+          } else if (commit.type === `test`) {
+              commit.type = `Tests`
+          } else if (commit.type === `build`) {
+              commit.type = `Build System`
+          // } else if (commit.type === `chore`) {
+          //     commit.type = `Maintenance`
+          } else if (commit.type === `ci`) {
+              commit.type = `Continuous Integration`
+          } else {
+              return
+          }
+
+          if (commit.scope === `*`) {
+              commit.scope = ``
+          }
+
+          if (typeof commit.hash === `string`) {
+              commit.hash = commit.hash.substring(0, 7)
+          }
+
+          if (typeof commit.subject === `string`) {
+              let url = context.repository
+                  ? `${context.host}/${context.owner}/${context.repository}`
+                  : context.repoUrl
+              if (url) {
+                  url = `${url}/issues/`
+                  // Issue URLs.
+                  commit.subject = commit.subject.replace(/#([0-9]+)/g, (_, issue) => {
+                      issues.push(issue)
+                      return `[#${issue}](${url}${issue})`
+                  })
+              }
+              if (context.host) {
+                  // User URLs.
+                  commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, username) => {
+                  if (username.includes('/')) {
+                      return `@${username}`
+                  }
+
+                  return `[@${username}](${context.host}/${username})`
+                  })
+              }
+          }
+
+          // remove references that already appear in the subject
+          commit.references = commit.references.filter(reference => {
+              if (issues.indexOf(reference.issue) === -1) {
+                  return true
+              }
+
+              return false
+          })
+
+          return commit
+      },
+    },
+  },
+};

--- a/ssf/files/tofs_ssf-formula/pre-commit_semantic-release.sh
+++ b/ssf/files/tofs_ssf-formula/pre-commit_semantic-release.sh
@@ -33,4 +33,5 @@ cd ..
 ###############################################################################
 # (C) Update `ssf/defaults.yaml` with `${nextRelease.version}`
 ###############################################################################
-sed -i -e "s_^\(\s\+body: '\* Automated using \`ssf-formula\` (\).*\()'\)_\1${1}\2_" ssf/defaults.yaml
+V_REPR=v${1}
+sed -i -e "s_^\(\s\+body: '\* Automated using \`ssf-formula\` (\).*\()'\)_\1${V_REPR}\2_" ssf/defaults.yaml


### PR DESCRIPTION
* References:
  - https://github.com/saltstack-formulas/php-formula/pull/175#issuecomment-517492613
  - https://github.com/saltstack-formulas/php-formula/pull/185#issuecomment-517603898
* Ensure this only runs until `v1.0.0` (done in the script)

---

The second commit is a fix for f9b74e3, which was missing the `v` prefix, found while working on the first commit.

CC: @n-rodriguez @sticky-note.