### PR TITLE
feat(vault): prepare for splitting suites for `vault-formula`

### DIFF
--- a/ssf/config/formulas.sls
+++ b/ssf/config/formulas.sls
@@ -106,6 +106,7 @@ prepare-git-branch-for-{{ formula }}:
         old_ci_files: {{ context.old_ci_files }}
         platforms: {{ context.platforms | yaml }}
         platforms_matrix: {{ context.platforms_matrix | yaml }}
+        platforms_matrix_commented_includes: {{ context.platforms_matrix_commented_includes | yaml }}
         script_kitchen: {{ context.script_kitchen | yaml }}
         suite: {{ suite | yaml }}
         travis: {{ context.travis | yaml }}

--- a/ssf/config/formulas.sls
+++ b/ssf/config/formulas.sls
@@ -46,41 +46,44 @@ prepare-git-branch-for-{{ formula }}:
 {%-     for index in range(0, inspec_suites_kitchen | length) %}
 {%-       set suite = inspec_suites_kitchen[index] %}
 {%-       set dest_file = semrel_file_specs.dest_file | d(semrel_file ) %}
-{%-       if dest_file.startswith('formula/') %}
-{#-         Replace 'formula/' with the actual name of the formula #}
-{%-         set dest_file = '{0}/{1}'.format(semrel_formula, dest_file.split('/')[-1]) %}
-{%-       elif dest_file.startswith('inspec/') %}
-{%-         set inspec_tests_path_prefix = suite.verifier.inspec_tests_path_prefix %}
-{%-         set test_suite = suite.verifier.test_suite %}
-{#-         The test suite to use may be a different than the suite's name, so need to point to it accordingly #}
-{%-         if test_suite not in ['.', suite.name] %}
-{%-           set dest_file = '' %}
-{%-         else %}
-{%-           set dest_file = '{0}/{1}/{2}'.format(inspec_tests_path_prefix, suite.name, dest_file.split('/')[-1]) %}
+{#-       Only manage files for the suite if the `suite.name` is set #}
+{#-       Or if dealing with CI files (where an empty `suite.name` is actually used) #}
+{%-       if suite.name or dest_file in ['.cirrus.yml', '.travis.yml'] %}
+{%-         if dest_file.startswith('formula/') %}
+{#-           Replace 'formula/' with the actual name of the formula #}
+{%-           set dest_file = '{0}/{1}'.format(semrel_formula, dest_file.split('/')[-1]) %}
+{%-         elif dest_file.startswith('inspec/') %}
+{%-           set inspec_tests_path_prefix = suite.verifier.inspec_tests_path_prefix %}
+{%-           set test_suite = suite.verifier.test_suite %}
+{#-           The test suite to use may be a different than the suite's name, so need to point to it accordingly #}
+{%-           if test_suite not in ['.', suite.name] %}
+{%-             set dest_file = '' %}
+{%-           else %}
+{%-             set dest_file = '{0}/{1}/{2}'.format(inspec_tests_path_prefix, suite.name, dest_file.split('/')[-1]) %}
+{%-           endif %}
 {%-         endif %}
-{%-       endif %}
-{%-       set dest = '{0}/{1}/{2}'.format(ssf.formulas_path, formula, dest_file) %}
-{#-       Only run the states for each suite if the same template is being used for each file (in each suite) #}
-{#-       Furthermore, only continue if the `dest_file` has actually been set #}
-{%-       if dest_file and dest_file not in dest_file_done %}
-{%-         do dest_file_done.append(dest_file) %}
+{%-         set dest = '{0}/{1}/{2}'.format(ssf.formulas_path, formula, dest_file) %}
+{#-         Only run the states for each suite if the same template is being used for each file (in each suite) #}
+{#-         Furthermore, only continue if the `dest_file` has actually been set #}
+{%-         if dest_file and dest_file not in dest_file_done %}
+{%-           do dest_file_done.append(dest_file) %}
 
-{#-         Add files by default #}
-{%-         set add_or_rm = ['add', 'add', 'managed'] %}
-{#-         Remove files if the file is `.cirrus.yml` and `use_cirrus_ci` is `False` #}
-{#-         Likewise, if running the state for TOFS files when `use_tofs` is `False` #}
-{%-         if (semrel_file == '.cirrus.yml' and not use_cirrus_ci) or
-               (semrel_file in ['docs/TOFS_pattern.rst', 'formula/libtofs.jinja'] and not use_tofs)
+{#-           Add files by default #}
+{%-           set add_or_rm = ['add', 'add', 'managed'] %}
+{#-           Remove files if the file is `.cirrus.yml` and `use_cirrus_ci` is `False` #}
+{#-           Likewise, if running the state for TOFS files when `use_tofs` is `False` #}
+{%-           if (semrel_file == '.cirrus.yml' and not use_cirrus_ci) or
+                 (semrel_file in ['docs/TOFS_pattern.rst', 'formula/libtofs.jinja'] and not use_tofs)
 %}
-{%-           set add_or_rm = ['rm', 'remove', 'absent'] %}
-{%-         endif %}
+{%-             set add_or_rm = ['rm', 'remove', 'absent'] %}
+{%-           endif %}
 
-{#-       Stage 2: Add or remove the file as necessary #}
+{#-           Stage 2: Add or remove the file as necessary #}
 {{ add_or_rm[1] }}-{{ formula }}-{{ dest_file }}:
   file.{{ add_or_rm[2] }}:
     - name: {{ dest }}
-    {#-     The rest of the settings only apply when adding files #}
-    {%-     if add_or_rm[0] == 'add' %}
+    {#-       The rest of the settings only apply when adding files #}
+    {%-       if add_or_rm[0] == 'add' %}
     - source: {{ files_switch([semrel_file],
                               default_files_switch=[formula_tofs_dir]
                  )
@@ -90,11 +93,11 @@ prepare-git-branch-for-{{ formula }}:
     - group: {{ ssf.group }}
     - makedirs: True
     - template: {{ template }}
-    {#-       Only send the `context` if a file template is being used #}
-    {%-       if template %}
+    {#-         Only send the `context` if a file template is being used #}
+    {%-         if template %}
     - context:
-        {#-     Using `| yaml` since `| json` (and `| tojson`) end up quoting the indexing for `inspec_suites_kitchen` #}
-        {#-     Maintaining the rest for consistency #}
+        {#-       Using `| yaml` since `| json` (and `| tojson`) end up quoting the indexing for `inspec_suites_kitchen` #}
+        {#-       Maintaining the rest for consistency #}
         tplroot: {{ tplroot }}
         semrel_formula: {{ semrel_file_specs.alt_semrel_formula | d(semrel_formula) }}
         formula: {{ formula }}
@@ -108,14 +111,14 @@ prepare-git-branch-for-{{ formula }}:
         travis: {{ context.travis | yaml }}
         use_cirrus_ci: {{ use_cirrus_ci }}
         yamllint: {{ context.yamllint | yaml }}
-    {%-       endif %}
-    {%-       if ssf.git.states.prepare.active %}
+    {%-         endif %}
+    {%-         if ssf.git.states.prepare.active %}
     - require:
       - cmd: prepare-git-branch-for-{{ formula }}
+    {%-         endif %}
     {%-       endif %}
-    {%-     endif %}
 
-  {%-       if ssf.git.states.add_rm.active %}
+  {%-         if ssf.git.states.add_rm.active %}
   cmd.run:
     - name: |
         git {{ add_or_rm[0] }} {{ dest_file }}
@@ -123,10 +126,11 @@ prepare-git-branch-for-{{ formula }}:
     - runas: {{ ssf.user }}
     - onchanges:
       - file: {{ add_or_rm[1] }}-{{ formula }}-{{ dest_file }}
-    {%-       if ssf.git.states.commit_push.active %}
+    {%-         if ssf.git.states.commit_push.active %}
     - onchanges_in:
       - cmd: commit-and-push-{{ formula }}
-    {%-       endif %}
+    {%-         endif %}
+{%-           endif %}
 {%-         endif %}
 {%-       endif %}
 {#-     [End] for index in range(0, inspec_suites_kitchen | length) #}

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -112,14 +112,14 @@ ssf_node_anchors:
           - [arch-base    , latest,   2017.7,      2]
         platforms_matrix:
           # Comments in `platforms` apply here, too
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
         script_kitchen:
           bin: bin/kitchen
           cmd: verify

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -37,7 +37,9 @@ ssf_node_anchors:
             # only `includes` will be considered, mimicking `kitchen list`
             # Note: This applies automatically via. `kitchen.yml`
             #       but is applied manually in the matrix (Travis/Cirrus)
-            # TODO: Use `kitchen list -b` output to define the matrix or too slow?
+            # Note: Cannot rely on `kitchen list` since there could end up being
+            #       far too many entries (e.g. `vault-formula` & `iptables-formula`)
+            #       Hence, the inclusion of `platforms_matrix_commented_includes`
             # yamllint disable-line rule:line-length
             # Ref: https://github.com/test-kitchen/test-kitchen/blob/7ce894e74f828f9e36531cf2d74588dd74fbf240/lib/kitchen/config.rb#L183-L193
             excludes: []
@@ -120,6 +122,9 @@ ssf_node_anchors:
           - [fedora       ,  29   ,   2018.3,      2,         default]
           - [opensuse/leap,  15   ,   2018.3,      2,         default]
           - [centos       ,   6   ,   2017.7,      2,         default]
+        # To deal with excessive instances when mimicking `kitchen list -b`
+        # If values are set, only use these as commented entries in the matrix
+        platforms_matrix_commented_includes: []
         script_kitchen:
           bin: bin/kitchen
           cmd: verify

--- a/ssf/files/default/.cirrus.yml
+++ b/ssf/files/default/.cirrus.yml
@@ -6,7 +6,7 @@ docker_builder:
   name: Test ${INSTANCE}
   env:
     matrix:
-      {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, semrel_formula, old_ci_files, width=6) }}
+      {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, old_ci_files, width=6) }}
   bundle_install_script: bundle install
   verify_script:
     {%- for pre_cmd in script_kitchen.pre %}

--- a/ssf/files/default/.travis.yml
+++ b/ssf/files/default/.travis.yml
@@ -53,7 +53,7 @@ env:
     # However, the groupings needed to be maintained in some semblance of order
     # so this is a best-effort matrix, in the circumstances
     {%- endif %}
-    {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, semrel_formula, old_ci_files) }}
+    {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, old_ci_files) }}
 
 script:
   {%- for pre_cmd in script_kitchen.pre %}

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -165,8 +165,9 @@ verifier:
 suites:
   {%- for index in range(0, inspec_suites_kitchen | length) %}
   {%-   set suite = inspec_suites_kitchen[index] %}
-  {#-   Do not include the suite if `includes: *includes_NONE` has been set #}
-  {%-   if not (suite.includes and not suite.includes[0]) %}
+  {#-   Only include the suite if the `suite.name` is set #}
+  {#-   Furthermore, do not include if `includes: *includes_NONE` has been set #}
+  {%-   if suite.name and not (suite.includes and not suite.includes[0]) %}
   - name: {{ suite.name }}
     {{- format_includes_excludes(suite, 'excludes') }}
     {{- format_includes_excludes(suite, 'includes') }}

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -110,32 +110,32 @@ ssf_node_anchors:
         #   - [amazonlinux  ,   2   ,   2018.3,      2]
         #   - [amazonlinux  ,   2   ,   2017.7,      2]
         platforms_matrix_osfamily_suites: &platforms_matrix_osfamily_suites
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,       debian]
-          - [ubuntu       ,  18.04,   2019.2,      3,       debian]
-          - [amazonlinux  ,   2   ,   2019.2,      2,       redhat]
-          - [fedora       ,  29   ,   2018.3,      2,       redhat]
-          - [opensuse/leap,  15   ,   2018.3,      2,         suse]
-          - [centos       ,   6   ,   2017.7,      2,       redhat]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,          debian]
+          - [ubuntu       ,  18.04,   2019.2,      3,          debian]
+          - [amazonlinux  ,   2   ,   2019.2,      2,          redhat]
+          - [fedora       ,  29   ,   2018.3,      2,          redhat]
+          - [opensuse/leap,  15   ,   2018.3,      2,            suse]
+          - [centos       ,   6   ,   2017.7,      2,          redhat]
         platforms_matrix_osfamily_debian: &platforms_matrix_osfamily_debian
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,  develop,      3,      default]
-          - [debian       ,   9   ,   2019.2,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [debian       ,   9   ,   2018.3,      2,      default]
-          - [ubuntu       ,  16.04,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,  develop,      3,         default]
+          - [debian       ,   9   ,   2019.2,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [debian       ,   9   ,   2018.3,      2,         default]
+          - [ubuntu       ,  16.04,   2017.7,      2,         default]
         platforms_matrix_systemd_only: &platforms_matrix_systemd_only
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [centos       ,   7   ,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          # - [centos       ,   6   ,   2017.7,      2,      default]
-          - [amazonlinux  ,   2   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [centos       ,   7   ,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          # - [centos       ,   6   ,   2017.7,      2,         default]
+          - [amazonlinux  ,   2   ,   2017.7,      2,         default]
         yamllint:
           rules:
             rule:
@@ -232,15 +232,15 @@ ssf:
           # - [debian       ,   8   ,   2017.7,      2]
           # - [ubuntu       ,  16.04,   2017.7,      2]
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3, repositories]
-          # - [ubuntu       ,  18.04,  develop,      3, repositories]
-          - [debian       ,   9   ,   2019.2,      3, repositories]
-          - [ubuntu       ,  18.04,   2019.2,      3, repositories]
-          - [debian       ,   9   ,  develop,      3,  preferences]
-          # - [ubuntu       ,  18.04,  develop,      3,  preferences]
-          - [debian       ,   9   ,   2019.2,      3,  preferences]
-          - [ubuntu       ,  18.04,   2019.2,      3,  preferences]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,    repositories]
+          # - [ubuntu       ,  18.04,  develop,      3,    repositories]
+          - [debian       ,   9   ,   2019.2,      3,    repositories]
+          - [ubuntu       ,  18.04,   2019.2,      3,    repositories]
+          - [debian       ,   9   ,  develop,      3,     preferences]
+          # - [ubuntu       ,  18.04,  develop,      3,     preferences]
+          - [debian       ,   9   ,   2019.2,      3,     preferences]
+          - [ubuntu       ,  18.04,   2019.2,      3,     preferences]
       semrel_files: *semrel_files_default
     apt-cacher:
       context:
@@ -336,15 +336,15 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/default/pillar/collectd.sls
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [centos       ,   7   ,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [centos       ,   7   ,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     cron:
       context:
@@ -373,35 +373,35 @@ ssf:
         platforms_matrix:
           # Note, keeping this "working out" because difficult to resolve for this repo
           # One `#` where working but not using, two `# #` for not working at all
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          # # - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,  develop,      3,      default]
-          # - [centos       ,   7   ,  develop,      3,      default]
-          # - [fedora       ,  30   ,  develop,      3,      default]
-          # - [opensuse/leap,  15   ,  develop,      3,      default]
-          # # - [amazonlinux  ,   2   ,  develop,      2,      default]
-          # # - [arch-base    , latest,  develop,      2,      default]
-          - [debian       ,   9   ,   2019.2,      3,      default]
-          # - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          # - [centos       ,   7   ,   2019.2,      3,      default]
-          - [fedora       ,  30   ,   2019.2,      3,      default]
-          # # - [opensuse/leap,  15   ,   2019.2,      3,      default]
-          # # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # # - [arch-base    , latest,   2019.2,      2,      default]
-          # # - [debian       ,   9   ,   2018.3,      2,      default]
-          # # - [ubuntu       ,  16.04,   2018.3,      2,      default]
-          - [centos       ,   7   ,   2018.3,      2,      default]
-          # - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          # # - [amazonlinux  ,   2   ,   2018.3,      2,      default]
-          # # - [arch-base    , latest,   2018.3,      2,      default]
-          # # - [debian       ,   8   ,   2017.7,      2,      default]
-          # # - [ubuntu       ,  16.04,   2017.7,      2,      default]
-          # # - [centos       ,   6   ,   2017.7,      2,      default]
-          - [fedora       ,  29   ,   2017.7,      2,      default]
-          # - [opensuse/leap,  15   ,   2017.7,      2,      default]
-          # # - [amazonlinux  ,   2   ,   2017.7,      2,      default]
-          # # - [arch-base    , latest,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          # # - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,  develop,      3,         default]
+          # - [centos       ,   7   ,  develop,      3,         default]
+          # - [fedora       ,  30   ,  develop,      3,         default]
+          # - [opensuse/leap,  15   ,  develop,      3,         default]
+          # # - [amazonlinux  ,   2   ,  develop,      2,         default]
+          # # - [arch-base    , latest,  develop,      2,         default]
+          - [debian       ,   9   ,   2019.2,      3,         default]
+          # - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          # - [centos       ,   7   ,   2019.2,      3,         default]
+          - [fedora       ,  30   ,   2019.2,      3,         default]
+          # # - [opensuse/leap,  15   ,   2019.2,      3,         default]
+          # # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # # - [arch-base    , latest,   2019.2,      2,         default]
+          # # - [debian       ,   9   ,   2018.3,      2,         default]
+          # # - [ubuntu       ,  16.04,   2018.3,      2,         default]
+          - [centos       ,   7   ,   2018.3,      2,         default]
+          # - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          # # - [amazonlinux  ,   2   ,   2018.3,      2,         default]
+          # # - [arch-base    , latest,   2018.3,      2,         default]
+          # # - [debian       ,   8   ,   2017.7,      2,         default]
+          # # - [ubuntu       ,  16.04,   2017.7,      2,         default]
+          # # - [centos       ,   6   ,   2017.7,      2,         default]
+          - [fedora       ,  29   ,   2017.7,      2,         default]
+          # - [opensuse/leap,  15   ,   2017.7,      2,         default]
+          # # - [amazonlinux  ,   2   ,   2017.7,      2,         default]
+          # # - [arch-base    , latest,   2017.7,      2,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     dhcpd:
@@ -425,15 +425,15 @@ ssf:
                 - '*':
                     - .config
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # - [arch-base    , latest,   2019.2,      2,      default]
-          - [centos       ,   7   ,   2018.3,      2,      default]
-          # - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # - [arch-base    , latest,   2019.2,      2,         default]
+          - [centos       ,   7   ,   2018.3,      2,         default]
+          # - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     exim:
       context:
@@ -470,16 +470,16 @@ ssf:
                     - misc.fake_log_files
                     - .
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  30   ,   2019.2,      3,      default]
-          - [centos       ,   7   ,   2018.3,      2,      default]
-          # - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  30   ,   2019.2,      3,         default]
+          - [centos       ,   7   ,   2018.3,      2,         default]
+          # - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     golang:
       context:
@@ -493,15 +493,15 @@ ssf:
                 Verify that the golang formula is setup and configured correctly
         use_tofs: true
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # - [arch-base    , latest,   2019.2,      2,      default]
-          - [debian       ,   9   ,   2018.3,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          # - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # - [arch-base    , latest,   2019.2,      2,         default]
+          - [debian       ,   9   ,   2018.3,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          # - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     grafana:
       context:
@@ -559,15 +559,15 @@ ssf:
           - default
           - tables
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [centos       ,   7   ,   2018.3,      2,      default]
-          # - [centos       ,   6   ,   2017.7,      2,      default]
-          - [opensuse/leap,  15   ,   2017.7,      2,       tables]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [centos       ,   7   ,   2018.3,      2,         default]
+          # - [centos       ,   6   ,   2017.7,      2,         default]
+          - [opensuse/leap,  15   ,   2017.7,      2,          tables]
         yamllint:
           rules:
             key-duplicates:
@@ -630,18 +630,18 @@ ssf:
           - share
           - clean
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [debian       ,  10   ,  develop,      3,        clean]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [fedora       ,  30   ,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # - [arch-base    , latest,   2019.2,      2,      default]
-          - [centos       ,   7   ,   2018.3,      2,      default]
-          # - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [fedora       ,  29   ,   2017.7,      2,      default]
-          # - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [debian       ,  10   ,  develop,      3,           clean]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [fedora       ,  30   ,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # - [arch-base    , latest,   2019.2,      2,         default]
+          - [centos       ,   7   ,   2018.3,      2,         default]
+          # - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [fedora       ,  29   ,   2017.7,      2,         default]
+          # - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     locale:
       context:
@@ -668,15 +668,15 @@ ssf:
           - default
           - fedora
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [centos       ,   7   ,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,       fedora]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [centos       ,   7   ,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,          fedora]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     logrotate:
       context:
@@ -721,20 +721,20 @@ ssf:
           # Everything else working, even if lines have been removed
           # Keeping hold of this "working out" for future reference
           # One `#` where working but not using, two `# #` for not working at all
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          # - [amazonlinux  ,   2   ,  develop,      2,      default]
-          # # - [arch-base    , latest,  develop,      2,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [fedora       ,  30   ,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # # - [arch-base    , latest,   2019.2,      2,      default]
-          - [centos       ,   7   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          # # - [arch-base    , latest,   2018.3,      2,      default]
-          # - [centos       ,   6   ,   2017.7,      2,      default]
-          - [amazonlinux  ,   2   ,   2017.7,      2,      default]
-          # # - [arch-base    , latest,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          # - [amazonlinux  ,   2   ,  develop,      2,         default]
+          # # - [arch-base    , latest,  develop,      2,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [fedora       ,  30   ,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # # - [arch-base    , latest,   2019.2,      2,         default]
+          - [centos       ,   7   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          # # - [arch-base    , latest,   2018.3,      2,         default]
+          # - [centos       ,   6   ,   2017.7,      2,         default]
+          - [amazonlinux  ,   2   ,   2017.7,      2,         default]
+          # # - [arch-base    , latest,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     mysql:
       context:
@@ -750,13 +750,13 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/mysql.sls
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,  develop,      3,      default]
-          - [debian       ,   9   ,   2019.2,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [debian       ,   9   ,   2018.3,      2,      default]
-          - [debian       ,   8   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,  develop,      3,         default]
+          - [debian       ,   9   ,   2019.2,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [debian       ,   9   ,   2018.3,      2,         default]
+          - [debian       ,   8   ,   2017.7,      2,         default]
         yamllint:
           ignore:
             additional:
@@ -776,15 +776,15 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/default/pillar/nginx.sls
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [centos       ,   7   ,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [centos       ,   7   ,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     openssh:
@@ -822,15 +822,15 @@ ssf:
                 - '*':
                     - .config
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # - [arch-base    , latest,   2019.2,      2,      default]
-          - [centos       ,   7   ,   2018.3,      2,      default]
-          # - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # - [arch-base    , latest,   2019.2,      2,         default]
+          - [centos       ,   7   ,   2018.3,      2,         default]
+          # - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     php:
       context:
@@ -946,15 +946,15 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/postgres.sls
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [centos       ,   7   ,   2019.2,      3,      default]
-          - [fedora       ,  30   ,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # - [arch-base    , latest,   2019.2,      2,      default]
-          - [ubuntu       ,  16.04,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [centos       ,   7   ,   2019.2,      3,         default]
+          - [fedora       ,  30   ,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # - [arch-base    , latest,   2019.2,      2,         default]
+          - [ubuntu       ,  16.04,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
         use_tofs: true
         yamllint:
           ignore:
@@ -995,15 +995,15 @@ ssf:
                     - .
                     - .server
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [centos       ,   7   ,   2019.2,      3,      default]
-          - [fedora       ,  30   ,   2019.2,      3,      default]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          # - [arch-base    , latest,   2019.2,      2,      default]
-          - [debian       ,   9   ,   2018.3,      2,      default]
-          - [ubuntu       ,  16.04,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [centos       ,   7   ,   2019.2,      3,         default]
+          - [fedora       ,  30   ,   2019.2,      3,         default]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          # - [arch-base    , latest,   2019.2,      2,         default]
+          - [debian       ,   9   ,   2018.3,      2,         default]
+          - [ubuntu       ,  16.04,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     rkhunter:
       context:
@@ -1046,13 +1046,13 @@ ssf:
           - redhat
           - suse
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,       debian]
-          - [ubuntu       ,  18.04,   2019.2,      3,       debian]
-          - [centos       ,   7   ,   2019.2,      3,       redhat]
-          - [fedora       ,  29   ,   2018.3,      2,       redhat]
-          - [opensuse/leap,  15   ,   2018.3,      2,         suse]
-          - [centos       ,   6   ,   2017.7,      2,       redhat]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,          debian]
+          - [ubuntu       ,  18.04,   2019.2,      3,          debian]
+          - [centos       ,   7   ,   2019.2,      3,          redhat]
+          - [fedora       ,  29   ,   2018.3,      2,          redhat]
+          - [opensuse/leap,  15   ,   2018.3,      2,            suse]
+          - [centos       ,   6   ,   2017.7,      2,          redhat]
         use_cirrus_ci: true
         use_tofs: true
       semrel_files: *semrel_files_default
@@ -1183,32 +1183,32 @@ ssf:
           - [fedora       ,  30   ,   2019.2,      3]
           - [opensuse/leap,  15   ,   2019.2,      3]
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          # - [debian       ,   8   ,   2017.7,      2,  v201707-py2]
-          - [ubuntu       ,  16.04,   2017.7,      2,  v201707-py2]
-          - [centos       ,   6   ,   2017.7,      2,  v201707-py2]
-          # # - [fedora       ,  29   ,   2017.7,      2,  v201707-py2]
-          # # - [opensuse/leap,  15   ,   2017.7,      2,  v201707-py2]
-          # - [amazonlinux  ,   2   ,   2017.7,      2,  v201707-py2]
-          # # - [arch-base    , latest,   2017.7,      2,    v201707-py2]
-          # - [debian       ,   9   ,   2018.3,      2,  v201803-py2]
-          # - [ubuntu       ,  16.04,   2018.3,      2,  v201803-py2]
-          - [centos       ,   7   ,   2018.3,      2,  v201803-py2]
-          # # - [fedora       ,  29   ,   2018.3,      2,  v201803-py2]
-          # # - [opensuse/leap,  15   ,   2018.3,      2,  v201803-py2]
-          - [amazonlinux  ,   2   ,   2018.3,      2,  v201803-py2]
-          # # - [arch-base    , latest,   2018.3,      2,    v201803-py2]
-          - [debian       ,   9   ,   2019.2,      2,  v201902-py2]
-          - [ubuntu       ,  18.04,   2019.2,      2,  v201902-py2]
-          # - [centos       ,   7   ,   2019.2,      2,  v201902-py2]
-          # - [opensuse/leap,  15   ,   2019.2,      2,  v201902-py2]
-          # - [amazonlinux  ,   2   ,   2019.2,      2,  v201902-py2]
-          # # - [arch-base    , latest,   2019.2,      2,    v201902-py2]
-          # - [debian       ,   9   ,   2019.2,      3,  v201902-py3]
-          # - [ubuntu       ,  18.04,   2019.2,      3,  v201902-py3]
-          # - [centos       ,   7   ,   2019.2,      3,  v201902-py3]
-          - [fedora       ,  30   ,   2019.2,      3,  v201902-py3]
-          - [opensuse/leap,  15   ,   2019.2,      3,  v201902-py3]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          # - [debian       ,   8   ,   2017.7,      2,     v201707-py2]
+          - [ubuntu       ,  16.04,   2017.7,      2,     v201707-py2]
+          - [centos       ,   6   ,   2017.7,      2,     v201707-py2]
+          # # - [fedora       ,  29   ,   2017.7,      2,     v201707-py2]
+          # # - [opensuse/leap,  15   ,   2017.7,      2,     v201707-py2]
+          # - [amazonlinux  ,   2   ,   2017.7,      2,     v201707-py2]
+          # # - [arch-base    , latest,   2017.7,      2,       v201707-py2]
+          # - [debian       ,   9   ,   2018.3,      2,     v201803-py2]
+          # - [ubuntu       ,  16.04,   2018.3,      2,     v201803-py2]
+          - [centos       ,   7   ,   2018.3,      2,     v201803-py2]
+          # # - [fedora       ,  29   ,   2018.3,      2,     v201803-py2]
+          # # - [opensuse/leap,  15   ,   2018.3,      2,     v201803-py2]
+          - [amazonlinux  ,   2   ,   2018.3,      2,     v201803-py2]
+          # # - [arch-base    , latest,   2018.3,      2,       v201803-py2]
+          - [debian       ,   9   ,   2019.2,      2,     v201902-py2]
+          - [ubuntu       ,  18.04,   2019.2,      2,     v201902-py2]
+          # - [centos       ,   7   ,   2019.2,      2,     v201902-py2]
+          # - [opensuse/leap,  15   ,   2019.2,      2,     v201902-py2]
+          # - [amazonlinux  ,   2   ,   2019.2,      2,     v201902-py2]
+          # # - [arch-base    , latest,   2019.2,      2,       v201902-py2]
+          # - [debian       ,   9   ,   2019.2,      3,     v201902-py3]
+          # - [ubuntu       ,  18.04,   2019.2,      3,     v201902-py3]
+          # - [centos       ,   7   ,   2019.2,      3,     v201902-py3]
+          - [fedora       ,  30   ,   2019.2,      3,     v201902-py3]
+          - [opensuse/leap,  15   ,   2019.2,      3,     v201902-py3]
         use_tofs: true
         yamllint:
           ignore:
@@ -1304,12 +1304,12 @@ ssf:
         platforms_matrix:
           # Couldn't use `*platforms_matrix_osfamily_debian` because it is
           # currently failing on both `ubuntu-16.04` and `debian-8`
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,  develop,      3,      default]
-          - [debian       ,   9   ,   2019.2,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [debian       ,   9   ,   2018.3,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,  develop,      3,         default]
+          - [debian       ,   9   ,   2019.2,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [debian       ,   9   ,   2018.3,      2,         default]
       semrel_files: *semrel_files_default
     sudoers:
       context:
@@ -1348,14 +1348,14 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/sysctl.sls
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          # - [centos       ,   6   ,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          # - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     syslog-ng:
       context:
@@ -1372,13 +1372,13 @@ ssf:
                 - '*':
                     - .config
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,  develop,      3,      default]
-          - [debian       ,   9   ,   2019.2,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [debian       ,   9   ,   2018.3,      2,      default]
-          # - [ubuntu       ,  16.04,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,  develop,      3,         default]
+          - [debian       ,   9   ,   2019.2,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [debian       ,   9   ,   2018.3,      2,         default]
+          # - [ubuntu       ,  16.04,   2017.7,      2,         default]
         use_cirrus_ci: true
       semrel_files:
         <<: *semrel_files_default
@@ -1490,14 +1490,14 @@ ssf:
           - default
           - centos6
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,      default]
-          - [ubuntu       ,  18.04,   2019.2,      3,      default]
-          - [amazonlinux  ,   2   ,   2019.2,      2,      default]
-          - [arch-base    , latest,   2019.2,      2,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [centos       ,   6   ,   2017.7,      2,      centos6]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         centos6]
         use_tofs: true
       semrel_files: *semrel_files_default
     timezone:
@@ -1528,14 +1528,14 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/default.sls
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [ubuntu       ,  18.04,  develop,      3,      default]
-          - [debian       ,   9   ,   2019.2,      3,      default]
-          - [centos       ,   7   ,   2019.2,      3,      default]
-          - [fedora       ,  29   ,   2018.3,      2,      default]
-          - [opensuse/leap,  15   ,   2018.3,      2,      default]
-          - [arch-base    , latest,   2018.3,      2,      default]
-          - [ubuntu       ,  16.04,   2017.7,      2,      default]
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [ubuntu       ,  18.04,  develop,      3,         default]
+          - [debian       ,   9   ,   2019.2,      3,         default]
+          - [centos       ,   7   ,   2019.2,      3,         default]
+          - [fedora       ,  29   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15   ,   2018.3,      2,         default]
+          - [arch-base    , latest,   2018.3,      2,         default]
+          - [ubuntu       ,  16.04,   2017.7,      2,         default]
         travis:
           # Facing errors with `xenial` at time of adding
           # https://travis-ci.org/myii/ufw-formula/jobs/561205378#L906
@@ -1593,14 +1593,14 @@ ssf:
         inspec_suites_matrix:
           - ''
         platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver, inspec_suite]
-          - [debian       ,  10   ,  develop,      3,           '']
-          - [ubuntu       ,  18.04,   2019.2,      3,           '']
-          - [fedora       ,  30   ,   2019.2,      3,           '']
-          - [amazonlinux  ,   2   ,   2019.2,      2,           '']
-          - [centos       ,   7   ,   2018.3,      2,           '']
-          - [opensuse/leap,  15   ,   2018.3,      2,           '']
-          - [arch-base    , latest,   2017.7,      2,           '']
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,  develop,      3,              '']
+          - [ubuntu       ,  18.04,   2019.2,      3,              '']
+          - [fedora       ,  30   ,   2019.2,      3,              '']
+          - [amazonlinux  ,   2   ,   2019.2,      2,              '']
+          - [centos       ,   7   ,   2018.3,      2,              '']
+          - [opensuse/leap,  15   ,   2018.3,      2,              '']
+          - [arch-base    , latest,   2017.7,      2,              '']
       semrel_files: *semrel_files_default
     vim:
       context:

--- a/ssf/libcimatrix.jinja
+++ b/ssf/libcimatrix.jinja
@@ -13,63 +13,60 @@
 {#-       Work through each inspec suite defined for the formula, ordered by the suite number #}
 {%-       for index in range(0, inspec_suites_kitchen | length) %}
 {%-         set suite = inspec_suites_kitchen[index] %}
-{#-         Prepare `includes` and `excludes` #}
-{%-         set suite_name = '' %}
-{%-         set includes = [] %}
-{%-         set excludes = [] %}
+{#-         Only continue if the `suite.name` is present in the given matrix #}
 {%-         if suite.name in inspec_suites_matrix %}
 {%-           set suite_name = suite.name %}
 {%-           set includes = suite.includes %}
 {%-           set excludes = suite.excludes %}
-{%-         endif %}
-{%-         set platform_and_suite_name = platform + [suite_name] %}
+{%-           set platform_and_suite_name = platform + [suite_name] %}
 {#-         Prevent using a `platform_and_suite_name` more than once #}
 {#-         I.e. In case suite_name resolves to `''` multiple times #}
-{%-         if platform_and_suite_name not in platform_and_suite_names_done %}
-{%-           do platform_and_suite_names_done.append(platform_and_suite_name) %}
-{#-           Only continue depending on an appropriate combination of `includes` and `excludes`: #}
-{#-           |---|-----|-----|--------|                                                          #}
-{#-           | #	| inc	| exc	| result |                                                          #}
-{#-           |---|-----|-----|--------|                                                          #}
-{#-           | 1	|  y	| []	|  TRUE  |                                                          #}
-{#-           | 2	|  y	|  n	|  TRUE  |                                                          #}
-{#-           | 3	|  y	|  y	|  TRUE  |                                                          #}
-{#-           | 4	| []	| []	|  TRUE  |                                                          #}
-{#-           | 5	| []	|  n	|  TRUE  |                                                          #}
-{#-           | 6	| []	|  y	| FALSE  |                                                          #}
-{#-           | 7	|  n	| []	| FALSE  |                                                          #}
-{#-           | 8	|  n	|  n	| FALSE  |                                                          #}
-{#-           | 9	|  n	|  y	| FALSE  |                                                          #}
-{#-           |---|-----|-----|--------|                                                          #}
-{%-           if (platform in includes) or (not includes and platform not in excludes) %}
-{#-             Compare combined [platform] and [suite_name] to see if enabled in the matrix #}
-{%-             if platform_and_suite_name in platforms_matrix %}
-{%-               set comment = '' %}
-{%-             else %}
-{%-               set comment = '# ' %}
-{%-             endif %}
-{#-             Only add a prefix if suite_name is given #}
-{%-             set prefix = '' %}
-{%-             if suite_name %}
-{%-               set prefix = suite_name|replace('_', '-') ~ '-' %}
-{%-             endif %}
-{#-             This `if` block is temporary and should eventually be removed #}
-{%-             if old_ci_files and loop.index0 == 0 %}
-{%-               if semrel_formula == 'postgres' and os == 'ubuntu' and os_ver == 18.04 %}
-# TODO: Re-enable this once the `systemd` service can be restarted reliably
-{%-               elif semrel_formula == 'openvpn' and os == 'fedora' and os_ver == 29 and salt_ver == 2018.3 and py_ver == 2 %}
-# Currently fails with "Cipher 'AES-256-GCM' mode not supported"
+{%-           if platform_and_suite_name not in platform_and_suite_names_done %}
+{%-             do platform_and_suite_names_done.append(platform_and_suite_name) %}
+{#-             Only continue depending on an appropriate combination of `includes` and `excludes`: #}
+{#-             |---|-----|-----|--------|                                                          #}
+{#-             | #	| inc	| exc	| result |                                                          #}
+{#-             |---|-----|-----|--------|                                                          #}
+{#-             | 1	|  y	| []	|  TRUE  |                                                          #}
+{#-             | 2	|  y	|  n	|  TRUE  |                                                          #}
+{#-             | 3	|  y	|  y	|  TRUE  |                                                          #}
+{#-             | 4	| []	| []	|  TRUE  |                                                          #}
+{#-             | 5	| []	|  n	|  TRUE  |                                                          #}
+{#-             | 6	| []	|  y	| FALSE  |                                                          #}
+{#-             | 7	|  n	| []	| FALSE  |                                                          #}
+{#-             | 8	|  n	|  n	| FALSE  |                                                          #}
+{#-             | 9	|  n	|  y	| FALSE  |                                                          #}
+{#-             |---|-----|-----|--------|                                                          #}
+{%-             if (platform in includes) or (not includes and platform not in excludes) %}
+{#-               Compare combined [platform] and [suite_name] to see if enabled in the matrix #}
+{%-               if platform_and_suite_name in platforms_matrix %}
+{%-                 set comment = '' %}
+{%-               else %}
+{%-                 set comment = '# ' %}
 {%-               endif %}
-{%-             endif %}
-{#-             Concatenate the `INSTANCE` #}
-{%-             set instance = '{0}{1}-{2}-{3}-py{4}'.format(
-                  prefix,
-                  os | replace('/', '-'),
-                  os_ver | replace('.', ''),
-                  salt_ver | replace('.', '-'),
-                  py_ver,
-                ) %}
+{#-               Only add a prefix if suite_name is given #}
+{%-               set prefix = '' %}
+{%-               if suite_name %}
+{%-                 set prefix = suite_name|replace('_', '-') ~ '-' %}
+{%-               endif %}
+{#-               This `if` block is temporary and should eventually be removed #}
+{%-               if old_ci_files and loop.index0 == 0 %}
+{%-                 if semrel_formula == 'postgres' and os == 'ubuntu' and os_ver == 18.04 %}
+# TODO: Re-enable this once the `systemd` service can be restarted reliably
+{%-                 elif semrel_formula == 'openvpn' and os == 'fedora' and os_ver == 29 and salt_ver == 2018.3 and py_ver == 2 %}
+# Currently fails with "Cipher 'AES-256-GCM' mode not supported"
+{%-                 endif %}
+{%-               endif %}
+{#-               Concatenate the `INSTANCE` #}
+{%-               set instance = '{0}{1}-{2}-{3}-py{4}'.format(
+                    prefix,
+                    os | replace('/', '-'),
+                    os_ver | replace('.', ''),
+                    salt_ver | replace('.', '-'),
+                    py_ver,
+                  ) %}
 {{ comment }}- INSTANCE: {{ instance }}
+{%-             endif %}
 {%-           endif %}
 {%-         endif %}
 {#-       [End] for index in range(0, inspec_suites_kitchen | length) #}

--- a/ssf/libcimatrix.jinja
+++ b/ssf/libcimatrix.jinja
@@ -51,7 +51,7 @@
 {#-             Only add a prefix if suite_name is given #}
 {%-             set prefix = '' %}
 {%-             if suite_name %}
-{%-               set prefix = suite_name ~ '-' %}
+{%-               set prefix = suite_name|replace('_', '-') ~ '-' %}
 {%-             endif %}
 {#-             This `if` block is temporary and should eventually be removed #}
 {%-             if old_ci_files and loop.index0 == 0 %}

--- a/ssf/libcimatrix.jinja
+++ b/ssf/libcimatrix.jinja
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
-{%- macro format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, semrel_formula, old_ci_files=False, width=4) %}
+{%- macro format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, old_ci_files=False, width=4) %}
 {%-   filter indent(width) %}
 {#-     Centralise duplication from here and `kitchen.yml` #}
 {%-     set platform_and_suite_names_done = [] %}
@@ -38,34 +38,40 @@
 {#-             | 9	|  n	|  y	| FALSE  |                                                          #}
 {#-             |---|-----|-----|--------|                                                          #}
 {%-             if (platform in includes) or (not includes and platform not in excludes) %}
+{%-               set include_instance = True %}
 {#-               Compare combined [platform] and [suite_name] to see if enabled in the matrix #}
 {%-               if platform_and_suite_name in platforms_matrix %}
 {%-                 set comment = '' %}
 {%-               else %}
 {%-                 set comment = '# ' %}
-{%-               endif %}
-{#-               Only add a prefix if suite_name is given #}
-{%-               set prefix = '' %}
-{%-               if suite_name %}
-{%-                 set prefix = suite_name|replace('_', '-') ~ '-' %}
-{%-               endif %}
-{#-               This `if` block is temporary and should eventually be removed #}
-{%-               if old_ci_files and loop.index0 == 0 %}
-{%-                 if semrel_formula == 'postgres' and os == 'ubuntu' and os_ver == 18.04 %}
-# TODO: Re-enable this once the `systemd` service can be restarted reliably
-{%-                 elif semrel_formula == 'openvpn' and os == 'fedora' and os_ver == 29 and salt_ver == 2018.3 and py_ver == 2 %}
-# Currently fails with "Cipher 'AES-256-GCM' mode not supported"
+{%-                 if platforms_matrix_commented_includes and platform_and_suite_name not in platforms_matrix_commented_includes %}
+{%-                   set include_instance = False %}
 {%-                 endif %}
 {%-               endif %}
-{#-               Concatenate the `INSTANCE` #}
-{%-               set instance = '{0}{1}-{2}-{3}-py{4}'.format(
-                    prefix,
-                    os | replace('/', '-'),
-                    os_ver | replace('.', ''),
-                    salt_ver | replace('.', '-'),
-                    py_ver,
-                  ) %}
+{%-               if include_instance %}
+{#-                 Only add a prefix if suite_name is given #}
+{%-                 set prefix = '' %}
+{%-                 if suite_name %}
+{%-                   set prefix = suite_name|replace('_', '-') ~ '-' %}
+{%-                 endif %}
+{#-                 This `if` block is temporary and should eventually be removed #}
+{%-                 if old_ci_files and loop.index0 == 0 %}
+{%-                   if semrel_formula == 'postgres' and os == 'ubuntu' and os_ver == 18.04 %}
+# TODO: Re-enable this once the `systemd` service can be restarted reliably
+{%-                   elif semrel_formula == 'openvpn' and os == 'fedora' and os_ver == 29 and salt_ver == 2018.3 and py_ver == 2 %}
+# Currently fails with "Cipher 'AES-256-GCM' mode not supported"
+{%-                   endif %}
+{%-                 endif %}
+{#-                 Concatenate the `INSTANCE` #}
+{%-                 set instance = '{0}{1}-{2}-{3}-py{4}'.format(
+                      prefix,
+                      os | replace('/', '-'),
+                      os_ver | replace('.', ''),
+                      salt_ver | replace('.', '-'),
+                      py_ver,
+                    ) %}
 {{ comment }}- INSTANCE: {{ instance }}
+{%-               endif %}
 {%-             endif %}
 {%-           endif %}
 {%-         endif %}


### PR DESCRIPTION
Split out from #45 so that it can be merged now, while the upstream PR is evaluated.

---

Had a number of steps to be done before this could be realised.

```
fix(libcimatrix): convert any underscores to hyphens for suite names
```

* `vault-formula` uses underscores, which translate into hyphens when checking with `kitchen list -b`.

```
feat: allow explicit specification of empty suites (i.e. `name: ''`)

* Empty suites are used to run all suites during the Travis run
* Before this, these were handled implicitly when they were set
  - E.g. `vault-formula` had 3 suites defined but all of them running
    for each instance
```

* This was the main body of work required to implement this functionality.
* Most of the diff is actually whitespace changes due to indenting one level further, due to the surrounding `if` block.

```
style(inspec_suite): increase column width for 15-character suite names
```

* Another issue was that `vault-formula` has a longer suite name than previously encountered (`install_binary`), so made space for that (and a little extra).

```
feat: allow limiting commented instances when mimicking `kitchen list`

* Otherwise can end up with too many commented entries in the matrix, e.g.:
  - `vault-formula`
  - `iptables-formula`
```

* Most of the diff is actually whitespace changes due to indenting one level further, due to the surrounding `if` block.

---

Note, this was tested with other formulas before confirmation:

* `iptables-formula` was a good candidate, due to suites which could be potentially overlapped.
* Checked generally with other formulas, to ensure it doesn't change anything.