### PR TITLE
feat(kitchen): use bootstrapped `opensuse` images until `2019.2.2`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -17,8 +17,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
-            title: 'test(inspec): add remaining platforms [skip ci]'
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/51'
+            title: 'ci(kitchen): use bootstrapped `opensuse` images until `2019.2.2` [skip ci]'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/52'
             # yamllint enable rule:line-length
           github:
             owner: saltstack-formulas

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -47,6 +47,61 @@
 {%-     endif %}
 {%-   endfilter %}
 {%- endmacro %}
+
+{%- macro format_driver_image(os, os_ver, salt_ver, py_ver) %}
+{%-   filter indent(6) %}
+image: netmanagers/salt-{{ salt_ver }}-py{{ py_ver }}:{{ os | replace('/', '-') }}-{{ os_ver }}
+{%-   endfilter %}
+{%- endmacro %}
+
+{%- macro format_driver_prov_cmds(os, os_ver, salt_ver, py_ver) %}
+{#-   TODO: Should really do this whole `if` block from `defaults.yaml` or `formulas.yaml`, just speeding things up right now #}
+{#-         Need to look at if this can be resolved from within the formulas themselves, though                               #}
+{%-   filter indent(6) %}
+{%-     set prov_cmds = [] %}
+{#-     Specific to `develop` #}
+{%-     if salt_ver == 'develop' %}
+{%-       do prov_cmds.append('- curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com') %}
+{%-       do prov_cmds.append('- sh bootstrap-salt.sh -XdPbfrq -x python{0} git {1}'.format(py_ver, salt_ver)) %}
+{%-       if semrel_formula == 'deepsea' %}
+{%-         if os in ['centos', 'fedora'] %}
+{%-           do prov_cmds.append('- yum install make -y') %}
+{%-         endif %}
+{%-       elif semrel_formula == 'golang' %}
+{%-         if os in ['debian', 'ubuntu'] %}
+{%-           do prov_cmds.append('# https://github.com/saltstack/salt/issues/39314') %}
+{%-           do prov_cmds.append('- apt-get remove python-boto3 -y') %}
+{%-         elif os == 'opensuse/leap' %}
+{%-           do prov_cmds.append('# https://github.com/saltstack/salt/issues/39314') %}
+{%-           do prov_cmds.append('- zypper rm python-boto3 -y') %}
+{%-         endif %}
+{%-       endif %}
+{%-     endif %}
+{#-     General for all Salt versions #}
+{%-     if semrel_formula == 'deepsea' %}
+{%-       if os == 'opensuse/leap' %}
+{%-         do prov_cmds.append('- zypper -n in tar gzip') %}
+{%-       endif %}
+{%-     endif %}
+{#-     Prepare the commands if available#}
+{%-     if prov_cmds %}
+provision_command:
+{%-       for prov_cmd in prov_cmds %}
+  {{ prov_cmd }}
+{%-       endfor %}
+{%-     endif %}
+{%-   endfilter %}
+{%- endmacro %}
+
+{%- macro format_driver_run_cmds(os, os_ver) %}
+{%-   filter indent(6) %}
+{%-     if os in ['opensuse/leap', 'arch-base'] %}
+run_command: /usr/lib/systemd/systemd
+{%-     elif [os, os_ver] == ['centos', 6] %}
+run_command: /sbin/init
+{%-     endif %}
+{%-   endfilter %}
+{%- endmacro %}
 # For help on this file's format, see https://kitchen.ci/
 driver:
   name: docker
@@ -100,41 +155,9 @@ platforms:
 {%-   else %}
   - name: {{ os | replace('/', '-') }}-{{ os_ver | replace('.', '') }}-{{ salt_ver | replace('.', '-') }}-py{{ py_ver }}
     driver:
-      image: netmanagers/salt-{{ salt_ver }}-py{{ py_ver }}:{{ os | replace('/', '-') }}-{{ os_ver }}
-      {%- if salt_ver == 'develop' %}
-      provision_command:
-        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
-        - sh bootstrap-salt.sh -XdPbfrq -x python{{ py_ver }} git develop
-        {#- TODO: Should really do this whole `if` block from `defaults.yaml` or `formulas.yaml`, just speeding things up right now #}
-        {#-       Need to look at if this can be resolved from within the formulas themselves, though                               #}
-        {%- if semrel_formula == 'deepsea' %}
-        {%-   if os in ['centos', 'fedora'] %}
-        - yum install make -y
-        {#-   Duplicated `provision_command` due to `deepsea`, try to remove eventually #}
-        {%-   elif os == 'opensuse/leap' %}
-        - zypper -n in tar gzip
-        {%-   endif %}
-        {%- elif semrel_formula == 'golang' %}
-        {%-   if os in ['debian', 'ubuntu'] %}
-        # https://github.com/saltstack/salt/issues/39314
-        - apt-get remove python-boto3 -y
-        {%-   elif os == 'opensuse/leap' %}
-        # https://github.com/saltstack/salt/issues/39314
-        - zypper rm python-boto3 -y
-        {%-   endif %}
-        {%- endif %}
-      {%- endif %}
-      {#- TODO: Should really do this whole `if` block from `defaults.yaml` or `formulas.yaml`, just speeding things up right now #}
-      {%- if os in ['opensuse/leap', 'arch-base'] %}
-      {%-   if os == 'opensuse/leap' and semrel_formula == 'deepsea' and salt_ver != 'develop' %}
-      {#-     Duplicated `provision_command` due to `deepsea`, try to remove eventually #}
-      provision_command:
-        - zypper -n in tar gzip
-      {%-   endif %}
-      run_command: /usr/lib/systemd/systemd
-      {%- elif os == 'centos' and os_ver == 6 %}
-      run_command: /sbin/init
-      {%- endif %}
+      {{- format_driver_image(os, os_ver, salt_ver, py_ver) }}
+      {{- format_driver_prov_cmds(os, os_ver, salt_ver, py_ver) }}
+      {{- format_driver_run_cmds(os, os_ver) }}
     {%- if [os, os_ver] == ['opensuse/leap', 15] %}
     # Workaround to avoid intermittent failures on `opensuse-leap-15`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -50,7 +50,11 @@
 
 {%- macro format_driver_image(os, os_ver, salt_ver, py_ver) %}
 {%-   filter indent(6) %}
+{%-     if os == 'opensuse/leap' %}
+image: {{ os }}:{{ os_ver }}
+{%-     else %}
 image: netmanagers/salt-{{ salt_ver }}-py{{ py_ver }}:{{ os | replace('/', '-') }}-{{ os_ver }}
+{%-     endif %}
 {%-   endfilter %}
 {%- endmacro %}
 
@@ -59,10 +63,16 @@ image: netmanagers/salt-{{ salt_ver }}-py{{ py_ver }}:{{ os | replace('/', '-') 
 {#-         Need to look at if this can be resolved from within the formulas themselves, though                               #}
 {%-   filter indent(6) %}
 {%-     set prov_cmds = [] %}
+{#-     Specific to unsalted `opensuse/leap` #}
+{%-     if os == 'opensuse/leap' %}
+{%-       do prov_cmds.append('- systemctl enable sshd.service') %}
+{%-     endif %}
 {#-     Specific to `develop` #}
 {%-     if salt_ver == 'develop' %}
-{%-       do prov_cmds.append('- curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com') %}
-{%-       do prov_cmds.append('- sh bootstrap-salt.sh -XdPbfrq -x python{0} git {1}'.format(py_ver, salt_ver)) %}
+{%-       if os != 'opensuse/leap' %}
+{%-         do prov_cmds.append('- curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com') %}
+{%-         do prov_cmds.append('- sh bootstrap-salt.sh -XdPbfrq -x python{0} git {1}'.format(py_ver, salt_ver)) %}
+{%-       endif %}
 {%-       if semrel_formula == 'deepsea' %}
 {%-         if os in ['centos', 'fedora'] %}
 {%-           do prov_cmds.append('- yum install make -y') %}
@@ -159,6 +169,9 @@ platforms:
       {{- format_driver_prov_cmds(os, os_ver, salt_ver, py_ver) }}
       {{- format_driver_run_cmds(os, os_ver) }}
     {%- if [os, os_ver] == ['opensuse/leap', 15] %}
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python{{ py_ver }} git {{ salt_ver }}
+      salt_install: bootstrap
     # Workaround to avoid intermittent failures on `opensuse-leap-15`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:


### PR DESCRIPTION
* The current pre-salted `opensuse` images are using `mirror.23media.com`
  - https://github.com/netmanagers/salt-image-builder/blob/d6e57f6b22570530a627c89a94fed02754a3197d/scripts/prepare.sh#L99
  - This has been proving to be unreliable in recent days, causing failed builds
* Preparing new pre-salted images would pull in `2019.2.1`, which is a no-go
  - https://github.com/netmanagers/salt-image-builder/issues/7
  - https://github.com/saltstack/salt/issues/54765
* This workaround is to use bootstrapped images in the interim

---

To do this effectively, had to prepare with another commit first:

```
refactor(kitchen): use macros for each section under `driver`
```

* Separated the logic in the `kitchen.yml` template, so that this workaround could be applied a bit more cleanly.

---

Final point, when it's time to use the pre-salted images again, only the second commit needs to be reverted (or a simulation of that).  It may be more appropriate to use a boolean value to be able to switch the selection as required.