### PR TITLE
fix(kitchen): install required packages to bootstrapped `opensuse`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -17,8 +17,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
-            title: 'ci(kitchen): use bootstrapped `opensuse` images until `2019.2.2` [skip ci]'
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/52'
+            title: 'ci(kitchen): install required packages to bootstrapped `opensuse` [skip ci]'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/53'
             # yamllint enable rule:line-length
           github:
             owner: saltstack-formulas

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -65,6 +65,10 @@ image: netmanagers/salt-{{ salt_ver }}-py{{ py_ver }}:{{ os | replace('/', '-') 
 {%-     set prov_cmds = [] %}
 {#-     Specific to unsalted `opensuse/leap` #}
 {%-     if os == 'opensuse/leap' %}
+{%-       do prov_cmds.append('# yamllint disable-line rule:line-length') %}
+{%-       do prov_cmds.append(
+            '- zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python{0}-pip'.format(py_ver)
+          ) %}
 {%-       do prov_cmds.append('- systemctl enable sshd.service') %}
 {%-     endif %}
 {#-     Specific to `develop` #}


### PR DESCRIPTION
* Completes #52
* Found when working on https://github.com/saltstack-formulas/vault-formula/pull/47
  - Wasn't necessary while testing on the `template-formula`
* List of packages taken from:
  - https://github.com/netmanagers/salt-image-builder/blob/d6e57f6b22570530a627c89a94fed02754a3197d/scripts/prepare.sh
  - Removed duplicate `net-tools`
  - Removed extraneous `udev` (installed already during initial provisioning)