### PR TITLE
feat(formulas): merge `rubocop` linter into main `lint` job

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -23,7 +23,7 @@ ssf_node_anchors:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
             title: 'ci(travis): merge `rubocop` linter into main `lint` job'
-            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/64'
+            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/65'
             # yamllint enable rule:line-length
           github:
             owner: saltstack-formulas

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1265,7 +1265,6 @@ ssf:
           # - [centos       ,   7   ,   2019.2,      3,     v201902-py3]
           - [fedora       ,  30   ,   2019.2,      3,     v201902-py3]
           - [opensuse/leap,  15   ,   2019.2,      3,     v201902-py3]
-        travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
         yamllint:
           ignore:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -434,7 +434,6 @@ ssf:
           # - [opensuse/leap,  15   ,   2017.7,      2,         default]
           # # - [amazonlinux  ,   2   ,   2017.7,      2,         default]
           # # - [arch-base    , latest,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files: *semrel_files_default
     dhcpd:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -978,7 +978,6 @@ ssf:
                 - '*':
                     - .
                     - .config
-        travis: *travis_do_not_use_single_job_for_linters
         yamllint:
           rules:
             key-duplicates:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -350,7 +350,6 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the chrony formula is setup and configured correctly
-        travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files: *semrel_files_default
     collectd:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -710,7 +710,6 @@ ssf:
           - [fedora       ,  29   ,   2018.3,      2,          fedora]
           - [opensuse/leap,  15   ,   2018.3,      2,         default]
           - [centos       ,   6   ,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     logrotate:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -282,7 +282,6 @@ ssf:
                 - '*':
                     - .ng.server
         platforms_matrix: *platforms_matrix_osfamily_debian
-        travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files:
         <<: *semrel_files_default

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -390,7 +390,6 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/cron.sls
         platforms_matrix: *platforms_matrix_without_arch
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     deepsea:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1606,7 +1606,6 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: test/salt/pillar/timezone.sls
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     ufw:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -478,7 +478,6 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/exim.sls
         platforms_matrix: *platforms_matrix_osfamily_debian
-        travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files: *semrel_files_default
     fail2ban:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1751,5 +1751,4 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: test/salt/pillar/vsftpd.sls
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -740,7 +740,6 @@ ssf:
                     - .
                     - .jobs
         platforms_matrix: *platforms_matrix_without_arch
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     lvm:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1398,7 +1398,10 @@ ssf:
                 - '*':
                     - .
                     - .included
-        travis: *travis_do_not_use_single_job_for_linters
+        rubocop:
+          Cops:
+            Metrics/BlockLength:
+              Max: 41
       semrel_files: *semrel_files_default
     sysctl:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -512,7 +512,6 @@ ssf:
           # - [fedora       ,  29   ,   2018.3,      2,         default]
           - [opensuse/leap,  15   ,   2018.3,      2,         default]
           - [centos       ,   6   ,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     golang:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1654,7 +1654,6 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/default.sls
         platforms_matrix: *platforms_matrix_without_arch
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     vault:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1527,7 +1527,6 @@ ssf:
           - [fedora       ,  30   ,   2019.2,      3,         default]
           - [opensuse/leap,  15   ,   2018.3,      2,         default]
           - [ubuntu       ,  16.04,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files: *semrel_files_default
     template:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -377,7 +377,6 @@ ssf:
           - [fedora       ,  29   ,   2018.3,      2,         default]
           - [opensuse/leap,  15   ,   2018.3,      2,         default]
           - [centos       ,   6   ,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     cron:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1744,7 +1744,6 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/vim.sls
         platforms_matrix: *platforms_matrix_without_arch
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     vsftpd:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1509,7 +1509,10 @@ ssf:
           - [amazonlinux  ,   2   ,   2017.7,      2]
           - [arch-base    , latest,   2017.7,      2]
         platforms_matrix: *platforms_matrix_systemd_only
-        travis: *travis_do_not_use_single_job_for_linters
+        rubocop:
+          Cops:
+            Metrics/BlockLength:
+              Max: 41
         use_tofs: true
       semrel_files: *semrel_files_default
     telegraf:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1367,7 +1367,6 @@ ssf:
           - [debian       ,   9   ,   2019.2,      3,         default]
           - [ubuntu       ,  18.04,   2019.2,      3,         default]
           - [debian       ,   9   ,   2018.3,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     sudoers:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -774,7 +774,6 @@ ssf:
           # - [centos       ,   6   ,   2017.7,      2,         default]
           - [amazonlinux  ,   2   ,   2017.7,      2,         default]
           # # - [arch-base    , latest,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     mysql:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1057,7 +1057,6 @@ ssf:
           - [debian       ,   9   ,   2018.3,      2,         default]
           - [ubuntu       ,  16.04,   2018.3,      2,         default]
           - [centos       ,   6   ,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     rkhunter:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1421,7 +1421,6 @@ ssf:
           - [fedora       ,  29   ,   2018.3,      2,         default]
           - [opensuse/leap,  15   ,   2018.3,      2,         default]
           # - [centos       ,   6   ,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     syslog-ng:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -559,7 +559,6 @@ ssf:
               pillars_from_files:
                 - .sls: test/salt/pillar/influxdb.sls
         platforms_matrix: *platforms_matrix_without_arch
-        travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     iptables:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -803,7 +803,6 @@ ssf:
           - [ubuntu       ,  18.04,   2019.2,      3,         default]
           - [debian       ,   9   ,   2018.3,      2,         default]
           - [debian       ,   8   ,   2017.7,      2,         default]
-        travis: *travis_do_not_use_single_job_for_linters
         yamllint:
           ignore:
             additional:
@@ -1265,6 +1264,7 @@ ssf:
           # - [centos       ,   7   ,   2019.2,      3,     v201902-py3]
           - [fedora       ,  30   ,   2019.2,      3,     v201902-py3]
           - [opensuse/leap,  15   ,   2019.2,      3,     v201902-py3]
+        travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
         yamllint:
           ignore:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -623,7 +623,6 @@ ssf:
           pre:
             - sudo modprobe ip_vs
         travis:
-          <<: *travis_do_not_use_single_job_for_linters
           addons:
             apt:
               packages:


### PR DESCRIPTION
The plan here is to clear the formulas where it is easy to fix this, e.g.

* `salt-formula`: Everything fixed automatically with `rubocop --safe-auto-correct`.