### PR TITLE
feat(ufw): remove `PyYAML` requirement for `salt-lint` in `.travis.yml`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
-            title: 'feat(semantic-release): implement for this formula'
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/78'
+            title: 'ci(travis): remove `PyYAML` workaround since fixed in `salt-lint` v0.0.9'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/80'
             # yamllint enable rule:line-length
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/.travis.yml
+++ b/ssf/files/default/.travis.yml
@@ -77,15 +77,14 @@ jobs:
       before_install: skip
       script:
         {%- set pip_cmd = 'pip' %}
-        {%- set pkgs_for_salt_lint = 'salt-lint' %}
         {%- if semrel_formula == 'ufw' %}
         {%-   set pip_cmd = 'pip3' %}
-        {%-   set pkgs_for_salt_lint = pkgs_for_salt_lint ~ ' PyYAML==4.2b4' %}
         # Need to use `pip3` due to using `{{ travis.dist }}` on Travis
+        # [Py2/InsecurePlatformWarning] Tornado requires an up-to-date SSL module.
         - sudo apt-get install python3-pip python3-setuptools python3-wheel -y
         {%- endif %}
         # Install and run `salt-lint`
-        - {{ pip_cmd }} install --user {{ pkgs_for_salt_lint }}
+        - {{ pip_cmd }} install --user salt-lint
         - git ls-files | grep '\.sls$\|\.jinja$\|\.j2$\|\.tmpl$'
                        | xargs -I {} salt-lint {}
         # Install and run `yamllint`


### PR DESCRIPTION
* https://github.com/warpnet/salt-lint/pull/49
* Removes part of the customisations of c3acbd103e62b4a5213e730f369c93084eda4140

---

Completed in https://github.com/saltstack-formulas/ufw-formula/commit/698dad815f4c74cc311300ec053a1f2c01fb6fbb.