### PR TITLE
feat(users): add `vimrc` suite (inc. allow multiple suites under `verifier`)

### DIFF
--- a/ssf/config/formulas.sls
+++ b/ssf/config/formulas.sls
@@ -57,9 +57,16 @@ prepare-git-branch-for-{{ formula }}:
               ) %}
 {%-         elif dest_file.startswith('inspec/') %}
 {%-           set inspec_tests_path_prefix = suite.verifier.inspec_tests_path_prefix %}
-{%-           set test_suite = suite.verifier.test_suite %}
 {#-           The test suite to use may be a different than the suite's name, so need to point to it accordingly #}
-{%-           if test_suite not in ['.', suite.name] %}
+{#-           Due to the `Scoping Behavior` of Jinja, can't use a straight `set` here, refer back to:
+              * https://jinja.palletsprojects.com/en/2.10.x/templates/#assignments
+              Unable to use `namespace` with the current version of Jinja so simulating with a `dict` instead #}
+{%-           set matching_test_suite = {'found': False} %}
+{%-           for test_suite in suite.verifier.inspec_tests if test_suite in ['.', suite.name] %}
+{%-               do matching_test_suite.update({'found': True}) %}
+{%-           endfor %}
+{#-           Now use that to set the `dest_file` accordingly #}
+{%-           if not matching_test_suite.found %}
 {%-             set dest_file = '' %}
 {%-           else %}
 {%-             set dest_file = '{0}/{1}/{2}'.format(inspec_tests_path_prefix, suite.name, dest_file.split('/')[-1]) %}

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -77,7 +77,8 @@ ssf_node_anchors:
                     - .
             verifier:
               inspec_tests_path_prefix: 'test/integration'
-              test_suite: '.'
+              inspec_tests:
+                - .
         inspec_suites_matrix:
           - default
         platforms:

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
-            title: 'feat(kitchen): implement Windows testing using `kitchen-vagrant`'
-            body: '* Checked using https://github.com/myii/ssf-formula/pull/81'
+            title: 'ci(kitchen+travis+inspec): add `vimrc` suite'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/91'
             # yamllint enable rule:line-length
           github:
             owner: 'saltstack-formulas'
@@ -439,7 +439,15 @@ ssf:
             name: 'centos6'
     timezone: *formula_default
     ufw: *formula_default
-    users: *formula_default
+    users:
+      <<: *formula_default
+      context:
+        <<: *context_default
+        inspec_suites_kitchen:
+          <<: *isk_default
+          1:
+            <<: *isk_suite_default
+            name: 'vimrc'
     vault:
       <<: *formula_default
       context:

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -239,10 +239,11 @@ suites:
     verifier:
       inspec_tests:
         {%- set inspec_tests_path_prefix = suite.verifier.inspec_tests_path_prefix %}
-        {%- set test_suite = suite.verifier.test_suite %}
-        {%- if test_suite == '.' %}
-        {%-   set test_suite = suite.name %}
-        {%- endif %}
+        {%- for test_suite in suite.verifier.inspec_tests %}
+        {%-   if test_suite == '.' %}
+        {%-     set test_suite = suite.name %}
+        {%-   endif %}
         - path: {{ inspec_tests_path_prefix }}/{{ test_suite }}
+        {%- endfor %}
   {%-   endif %}
   {%- endfor %}

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -36,6 +36,9 @@ ssf_node_anchors:
                     - .pkgrepo
                     - .master
                     - .minion
+            verifier: &verifier_inspec_tests_default
+              inspec_tests:
+                - default
         platforms_osfamily_debian: &platforms_osfamily_debian
           # [os           , os_ver, salt_ver, py_ver]
           - [debian       ,  10   ,   master,      3]
@@ -808,8 +811,7 @@ ssf:
                     - lvm.pv.create
                     - .
                     - .clean
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
         inspec_suites_matrix:
           - default
           - centarch
@@ -1000,8 +1002,7 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/redhat.sls'
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
         inspec_suites_matrix:
           - default
           - redhat
@@ -1242,8 +1243,7 @@ ssf:
                     - .fpm.pools
                     - .modules
                     - .fpm.service
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
           2:
             includes: *platforms_os_ubuntu
             provisioner:
@@ -1262,22 +1262,19 @@ ssf:
                     - .fpm.pools
                     - .modules
                     - .fpm.service
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
           3:
             includes: *platforms_osfamily_redhat
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/redhat.sls'
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
           4:
             includes: *platforms_osfamily_suse
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/suse.sls'
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
         inspec_suites_matrix:
           - default
           - debian
@@ -1421,22 +1418,19 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/debian.sls'
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
           2:
             includes: *platforms_osfamily_redhat
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/redhat.sls'
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
           3:
             includes: *platforms_osfamily_suse
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/suse.sls'
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
         inspec_suites_matrix:
           - default
           - debian
@@ -1929,8 +1923,7 @@ ssf:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/centos6.sls'
                 - define_roles.sls: 'test/salt/pillar/define_roles.sls'
-            verifier:
-              test_suite: 'default'
+            verifier: *verifier_inspec_tests_default
         inspec_suites_matrix:
           - default
           - centos6

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2009,7 +2009,76 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/default.sls'
-        platforms_matrix: *platforms_matrix_without_arch
+          1:
+            inspec_yml:
+              summary: >-
+                Verify that the `.vimrc` file is configured correctly for
+                specified users
+            provisioner:
+              dependencies:
+                - name: 'vim'
+                  repo: 'git'
+                  source: 'https://github.com/saltstack-formulas/vim-formula.git'
+              pillars:
+                - '*':
+                    - .
+                    - vimrc
+              pillars_from_files:
+                - .sls: 'test/salt/pillar/default.sls'
+                - vimrc.sls: 'test/salt/pillar/vimrc.sls'
+              state_top:
+                - '*':
+                    - .vimrc
+            verifier:
+              inspec_tests:
+                - default
+                - .
+        inspec_suites_matrix:
+          - default
+          - vimrc
+        platforms_matrix:
+          # Based on `*platforms_matrix_without_arch`
+          - [debian       ,  10   ,   master,      3,           vimrc]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [opensuse/leap,  15.1 ,   2019.2,      3,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [fedora       ,  30   ,   2018.3,      3,         default]
+          # - [arch-base    , latest,   2018.3,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
+        # To deal with excessive instances when mimicking `kitchen list -b`
+        # If values are set, only use these as commented entries in the matrix
+        platforms_matrix_commented_includes:
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,   master,      3,         default]
+          - [ubuntu       ,  18.04,   master,      3,         default]
+          - [centos       ,   8   ,   master,      3,         default]
+          - [fedora       ,  31   ,   master,      3,         default]
+          - [opensuse/leap,  15.1 ,   master,      3,         default]
+          - [amazonlinux  ,   2   ,   master,      2,         default]
+          - [arch-base    , latest,   master,      2,         default]
+          - [debian       ,  10   ,   2019.2,      3,         default]
+          - [debian       ,   9   ,   2019.2,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [centos       ,   8   ,   2019.2,      3,         default]
+          - [fedora       ,  31   ,   2019.2,      3,         default]
+          - [opensuse/leap,  15.1 ,   2019.2,      3,         default]
+          - [centos       ,   7   ,   2019.2,      2,         default]
+          - [amazonlinux  ,   2   ,   2019.2,      2,         default]
+          - [arch-base    , latest,   2019.2,      2,         default]
+          - [fedora       ,  30   ,   2018.3,      3,         default]
+          - [debian       ,   9   ,   2018.3,      2,         default]
+          - [ubuntu       ,  16.04,   2018.3,      2,         default]
+          - [centos       ,   7   ,   2018.3,      2,         default]
+          - [opensuse/leap,  15.1 ,   2018.3,      2,         default]
+          - [amazonlinux  ,   2   ,   2018.3,      2,         default]
+          - [arch-base    , latest,   2018.3,      2,         default]
+          - [debian       ,   8   ,   2017.7,      2,         default]
+          - [ubuntu       ,  16.04,   2017.7,      2,         default]
+          - [centos       ,   6   ,   2017.7,      2,         default]
+          - [fedora       ,  30   ,   2017.7,      2,         default]
+          - [opensuse/leap,  15.1 ,   2017.7,      2,         default]
+          - [amazonlinux  ,   2   ,   2017.7,      2,         default]
+          - [arch-base    , latest,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     vault:
       context:


### PR DESCRIPTION
* https://github.com/saltstack-formulas/users-formula/issues/213
* https://github.com/saltstack-formulas/users-formula/pull/214

---

This also includes adapting the formula to deal with multiple suites under `verifier`, to reuse existing test suites where appropriate (in this case, running both the `default` and the `vimrc` tests).