### PR TITLE
feat(django): use default matrix after `centos-6` image fix

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
-            title: 'feat(semantic-release): implement for this formula'
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/103'
+            title: 'ci(travis): use default matrix after `centos-6` image fix'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/105'
             # yamllint enable rule:line-length
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -553,15 +553,6 @@ ssf:
               state_top:
                 - '*':
                     - .pip
-        platforms_matrix:
-          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,  10   ,   master,      3,         default]
-          - [ubuntu       ,  18.04,   2019.2,      3,         default]
-          - [centos       ,   8   ,   2019.2,      3,         default]
-          - [opensuse/leap,  15.1 ,   2019.2,      3,         default]
-          - [fedora       ,  30   ,   2018.3,      3,         default]
-          - [arch-base    , latest,   2018.3,      2,         default]
-          - [amazonlinux  ,   2   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     docker:
       context:


### PR DESCRIPTION
* https://github.com/netmanagers/salt-image-builder/issues/18
* https://github.com/netmanagers/salt-image-builder/commit/0b05d8f9cf718f1f68bba5196a81ee13e2f2789f