### PR TITLE
feat(gemfile): restrict `train` gem version until upstream fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ source 'https://rubygems.org'
 gem 'kitchen-docker', '>= 2.9'
 gem 'kitchen-inspec', '>= 1.1'
 gem 'kitchen-salt', '>= 0.6.0'
+# Latest versions of `train` cause failure when running `kitchen verify`
+# Downgrading to `3.2.0` until this is fixed upstream
+# https://github.com/inspec/train/pull/544#issuecomment-566055052
+gem 'train', '3.2.0'

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
-            title: 'feat(semantic-release): implement for this formula'
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/109'
+            title: 'ci(gemfile): restrict `train` gem version until upstream fix [skip ci]'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/110'
             # yamllint enable rule:line-length
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/Gemfile
+++ b/ssf/files/default/Gemfile
@@ -5,3 +5,7 @@ source 'https://rubygems.org'
 gem 'kitchen-docker', '>= 2.9'
 gem 'kitchen-inspec', '>= 1.1'
 gem 'kitchen-salt', '>= 0.6.0'
+# Latest versions of `train` cause failure when running `kitchen verify`
+# Downgrading to `3.2.0` until this is fixed upstream
+# https://github.com/inspec/train/pull/544#issuecomment-566055052
+gem 'train', '3.2.0'

--- a/ssf/files/tofs_openvpn-formula/Gemfile
+++ b/ssf/files/tofs_openvpn-formula/Gemfile
@@ -2,11 +2,14 @@
 
 source 'https://rubygems.org'
 
-gem 'inspec'
 gem 'kitchen-docker', '>= 2.9'
 gem 'kitchen-inspec', '>= 1.1'
 gem 'kitchen-salt', '>= 0.6.0'
 gem 'rspec-retry'
+# Latest versions of `train` cause failure when running `kitchen verify`
+# Downgrading to `3.2.0` until this is fixed upstream
+# https://github.com/inspec/train/pull/544#issuecomment-566055052
+gem 'train', '3.2.0'
 
 group :vagrant do
   gem 'kitchen-vagrant'

--- a/ssf/files/tofs_vault-formula/Gemfile
+++ b/ssf/files/tofs_vault-formula/Gemfile
@@ -6,3 +6,7 @@ gem 'inspec',      '~> 4.16.0'
 gem 'kitchen-docker', '>= 2.9'
 gem 'kitchen-inspec', '>= 1.1'
 gem 'kitchen-salt', '>= 0.6.0'
+# Latest versions of `train` cause failure when running `kitchen verify`
+# Downgrading to `3.2.0` until this is fixed upstream
+# https://github.com/inspec/train/pull/544#issuecomment-566055052
+gem 'train', '3.2.0'


### PR DESCRIPTION
* Latest versions of `train` cause failure when running `kitchen verify`
* Downgrading to `3.2.0` until this is fixed upstream
* https://github.com/inspec/train/pull/544#issuecomment-566055052