### PR TITLE
feat(travis): use `major.minor` for `semantic-release` version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ jobs:
         # Deprecated `skip_cleanup` can now be avoided, `cleanup: false` is by default
         edge: true
         # Run `semantic-release`
-        script: 'npx semantic-release@15'
+        script: 'npx semantic-release@15.14'

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
-            title: 'ci(travis): condense jobs by using a multi-suite job'
-            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/111'
+            title: 'ci(travis): use `major.minor` for `semantic-release` version [skip ci]'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/112'
             # yamllint enable rule:line-length
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/.travis.yml
+++ b/ssf/files/default/.travis.yml
@@ -208,4 +208,4 @@ jobs:
         # Deprecated `skip_cleanup` can now be avoided, `cleanup: false` is by default
         edge: true
         # Run `semantic-release`
-        script: 'npx semantic-release@15'
+        script: 'npx semantic-release@15.14'


### PR DESCRIPTION
* https://github.com/saltstack-formulas/bind-formula/issues/143#issuecomment-568197176
* https://travis-ci.com/saltstack-formulas/bind-formula/jobs/269513751#L266-L267
  - `15.4.0` being used instead of newly released `15.14.0`