### PR TITLE
feat(mattermost): adjust Travis matrix to use `systemd` platforms only

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length
-            title: 'feat(semantic-release): update for this formula'
-            body: '* Updated using https://github.com/myii/ssf-formula/pull/34'
+            title: 'ci(travis): adjust matrix to use `systemd` platforms only'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/120'
             # yamllint enable rule:line-length
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1177,6 +1177,16 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/default/pillar/mattermost.sls'
+        # Based on `platforms_matrix_systemd_only`,
+        # simply because `centos-6` not working
+        platforms_matrix:
+          # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,  10   ,   master,      3,         default]
+          - [ubuntu       ,  18.04,   2019.2,      3,         default]
+          - [centos       ,   8   ,   2019.2,      3,         default]
+          - [fedora       ,  30   ,   2018.3,      3,         default]
+          - [arch-base    , latest,   2018.3,      2,         default]
+          - [amazonlinux  ,   2   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     mongodb:
       context:


### PR DESCRIPTION
* https://github.com/kjkeane/mattermost-formula/pull/25