### PR TITLE
feat(firewalld): relax rubocop `Metrics/BlockLength` for new tests

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(kitchen+travis): adjust matrix to update '`'3000'`' to '`'3000.1'`' [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/146'
+            title: "chore(rubocop): relax '`'Metrics/BlockLength'`' for new tests"
+            body: '* Checked using https://github.com/myii/ssf-formula/pull/145'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -789,6 +789,10 @@ ssf:
           - [opensuse/leap,  15.1 ,   2018.3,      2,         default]
           - [arch-base    , latest,   2018.3,      2,         default]
           # - [ubuntu       ,  16.04,   2017.7,      2,         default]
+        rubocop:
+          Cops:
+            Metrics/BlockLength:
+              Max: 39
       semrel_files: *semrel_files_default
     golang:
       context:


### PR DESCRIPTION
* https://github.com/saltstack-formulas/firewalld-formula/pull/40