### PR TITLE
feat(libsaltcli): update `salt-ssh` detection for `enable_ssh_minions`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "test: verify map output using '`'yaml_dump'`'"
-            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/159'
+            title: "fix(libsaltcli): update '`'salt-ssh'`' detection for '`'enable_ssh_minions'`'"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/161'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/.travis.yml
+++ b/ssf/files/default/.travis.yml
@@ -190,6 +190,8 @@ jobs:
         - cd tmp/converted-formula
         - DEBUG=true bin/convert-formula.sh converted
         - '[ $(git rev-list HEAD --count) -eq 2 ]'
+        # Quick visual check that correct files have been updated
+        - git show --pretty="" --name-status
         - bin/kitchen verify default-debian-10-2019-2-py3
     # REMOVEME>
     {%- endif %}

--- a/ssf/files/default/formula/libsaltcli.jinja
+++ b/ssf/files/default/formula/libsaltcli.jinja
@@ -9,7 +9,7 @@
 {%- if opts_cli == 'salt-minion' %}
 {%-   set cli = 'minion' %}
 {%- elif opts_cli == 'salt-call' %}
-{%-   set cli = 'ssh' if opts_masteropts_cli == 'salt-ssh' else 'local' %}
+{%-   set cli = 'ssh' if opts_masteropts_cli in ('salt-ssh', 'salt-master') else 'local' %}
 {%- else %}
 {%-   set cli = 'unknown' %}
 {%- endif %}


### PR DESCRIPTION
* Explained by @max-arnold:
  - https://github.com/saltstack-formulas/template-formula/commit/69b632fbe613d4f99a48f59f64ec93c3897431c8#r38597329

---

Also a second commit to catch up with changes from:

* https://github.com/saltstack-formulas/template-formula/pull/194