### PR TITLE
feat(telegraf): avoid `master` instances due to `toml` issues [skip ci]

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -22,8 +22,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(kitchen+travis): remove '`'master-py2-arch-base-latest'`' [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/167'
+            title: "ci(travis): avoid '`'master'`' instances due to '`'toml'`' issues [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/168'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2458,9 +2458,9 @@ ssf:
                 - .sls: 'test/salt/pillar/telegraf.sls'
         platforms_matrix:
           # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,  10   ,   master,      3,         default]
-          - [centos       ,   8   ,   master,      3,         default]
-          - [fedora       ,  31   ,   master,      3,         default]
+          - [debian       ,  10   ,   2019.2,      3,         default]
+          - [centos       ,   8   ,   2019.2,      3,         default]
+          - [fedora       ,  31   ,   2019.2,      3,         default]
           - [ubuntu       ,  18.04,   2019.2,      3,         default]
           - [centos       ,   7   ,   2019.2,      2,         default]
           - [debian       ,   9   ,   2018.3,      2,         default]


### PR DESCRIPTION
* https://tree.taiga.io/project/myii-saltstack-formulas/task/187
* https://travis-ci.org/github/myii/telegraf-formula/builds/681360474 (before)
* https://travis-ci.org/github/myii/telegraf-formula/builds/682200993 (after)

Quoting from Slack #testing channel:

> Final issue with this test run: the `telegraf-formula` is failing
> completely, due to `toml` issues:
> https://travis-ci.org/github/myii/telegraf-formula/builds/681360474.
> I'm vaguely aware that something has changed in this regard for Sodium,
> so probably the formula needs to change?
> 
> ```
> ID: telegraf/config/install
> Function: file.managed
>     Name: /etc/telegraf/telegraf.conf
>   Result: False
>  Comment: Unable to manage file: Jinja error: module 'toml' has no attribute 'dumps'
>    Traceback (most recent call last):
>      File "/usr/local/lib/python3.7/dist-packages/salt/serializers/toml.py", line 63, in serialize
>        return toml.dumps(obj, **options)
>    AttributeError: module 'toml' has no attribute 'dumps'
>    
>    During handling of the above exception, another exception occurred:
>    
>    Traceback (most recent call last):
>      File "/usr/local/lib/python3.7/dist-packages/salt/utils/templates.py", line 400, in render_jinja_tmpl
>        output = template.render(**decoded_context)
>      File "/usr/local/lib/python3.7/dist-packages/jinja2/environment.py", line 1090, in render
>        self.environment.handle_exception()
>      File "/usr/local/lib/python3.7/dist-packages/jinja2/environment.py", line 832, in handle_exception
>        reraise(*rewrite_traceback_stack(source=source))
>      File "/usr/local/lib/python3.7/dist-packages/jinja2/_compat.py", line 28, in reraise
>        raise value.with_traceback(tb)
>      File "<template>", line 6, in top-level template code
>      File "/usr/local/lib/python3.7/dist-packages/salt/modules/slsutil.py", line 224, in serialize
>        return _get_serialize_fn(serializer, "serialize")(obj, **kwargs)
>      File "/usr/local/lib/python3.7/dist-packages/salt/serializers/toml.py", line 65, in serialize
>        raise SerializationError(error)
>    salt.serializers.SerializationError: module 'toml' has no attribute 'dumps'
> ```
> 
> ---
> 
> toml update was to migrate from pytoml to toml library:
> https://github.com/saltstack/salt/pull/56615
> 
> Should have been a painless change, but I guess not. There weren't any
> tests for the serializer, so I made one. If I get some spare time this
> week, I'll see if I can take a look. There's not much to the serializer