### PR TITLE
feat(codeowners): manage across formulas

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,11 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# FILE PATTERN                 OWNER(S)
-*                              @myii
+# SECTION: Owner(s) for everything in the repo, unless a later match takes precedence
+# FILE PATTERN                              OWNER(S)
+*                                           @myii
+
+# SECTION: Owner(s) for files/directories related to `semantic-release`
+# FILE PATTERN                              OWNER(S)
+
+# SECTION: Owner(s) for specific files/directories
+# FILE PATTERN                              OWNER(S)

--- a/pillar.example
+++ b/pillar.example
@@ -161,6 +161,7 @@ ssf:
       - .travis.yml
       - .yamllint
       - commitlint.config.js
+      - CODEOWNERS
       - Gemfile
       - Gemfile.lock
       - kitchen.yml

--- a/ssf/config/formulas.sls
+++ b/ssf/config/formulas.sls
@@ -11,6 +11,7 @@
 {#- Work through each formula, which is in the `active` list via. pillar/config #}
 {%- for semrel_formula, semrel_formula_specs in ssf.semrel_formulas.items() if semrel_formula in ssf.active.semrel_formulas %}
 {#-   Use shorter variables to make the code a little easier to follow #}
+{%-   set codeowners = semrel_formula_specs.codeowners %}
 {%-   set context = semrel_formula_specs.context %}
 {%-   set inspec_suites_kitchen = context.inspec_suites_kitchen %}
 {%-   set use_cirrus_ci = context.use_cirrus_ci %}
@@ -126,6 +127,7 @@ prepare-git-branch-for-{{ formula }}:
         tplroot: {{ tplroot }}
         semrel_formula: {{ semrel_file_specs.alt_semrel_formula | d(semrel_formula) }}
         formula: {{ formula }}
+        codeowners: {{ codeowners | yaml }}
         inspec_suites_kitchen: {{ inspec_suites_kitchen | yaml }}
         inspec_suites_matrix: {{ context.inspec_suites_matrix | yaml }}
         platforms: {{ context.platforms | yaml }}

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -9,6 +9,34 @@ ssf_node_anchors:
           bugbear: &line_length_bugbear 88
           default: &line_length_default 80
     formula: &formula_default
+      codeowners:
+        col_width: 43
+        entries:
+          global: []
+          specific_directories: []
+          specific_ssf:
+            - '/.github/workflows/': '@saltstack-formulas/ssf'
+            - '/bin/kitchen': '@saltstack-formulas/ssf'
+            - '/docs/TOFS_pattern.rst': '@saltstack-formulas/ssf'
+            - '/./libsaltcli.jinja': '@saltstack-formulas/ssf'
+            - '/./libtofs.jinja': '@saltstack-formulas/ssf'
+            - '/test/integration/**/inspec.yml': '@saltstack-formulas/ssf'
+            - '/test/integration/**/README.md': '@saltstack-formulas/ssf'
+            - '/.gitignore': '@saltstack-formulas/ssf'
+            - '/.cirrus.yml': '@saltstack-formulas/ssf'
+            - '/.rubocop.yml': '@saltstack-formulas/ssf'
+            - '/.salt-lint': '@saltstack-formulas/ssf'
+            - '/.travis.yml': '@saltstack-formulas/ssf'
+            - '/.yamllint': '@saltstack-formulas/ssf'
+            - '/commitlint.config.js': '@saltstack-formulas/ssf'
+            - '/CODEOWNERS': '@saltstack-formulas/ssf'
+            - '/Gemfile': '@saltstack-formulas/ssf'
+            - '/Gemfile.lock': '@saltstack-formulas/ssf'
+            - '/kitchen.yml': '@saltstack-formulas/ssf'
+            - '/pre-commit_semantic-release.sh': '@saltstack-formulas/ssf'
+            - '/release-rules.js': '@saltstack-formulas/ssf'
+            - '/release.config.js': '@saltstack-formulas/ssf'
+          specific_files: []
       context: &context_default
         git:
           branch:
@@ -22,8 +50,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(workflows/commitlint): add to repo [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/172'
+            title: "chore(codeowners): add to repo [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/173'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/CODEOWNERS
+++ b/ssf/files/default/CODEOWNERS
@@ -1,0 +1,30 @@
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+{%- set heading = '{0:<{2}} {1}'.format('# FILE PATTERN', 'OWNER(S)', codeowners.col_width) %}
+{%- macro format_entries(section, description) %}
+
+# SECTION: Owner(s) for {{ description }}
+{%-   set entries_section = codeowners.entries.get(section) %}
+{%-   if  section == 'global' and not entries_section %}
+#          **************************************************************************
+#          ***                    NO GLOBAL OWNER(S) SPECIFIED                    ***
+#          ***  Ideally this will be defined for a healthy, well-maintained repo  ***
+#          **************************************************************************
+{{ heading }}
+{{ '{0:<{2}} {1}'.format('*', '@NONE', codeowners.col_width) }}
+{%-   else %}
+{{ heading }}
+{%-     for entry in entries_section %}
+{%-       for file_pattern, owners in entry.items() %}
+{%-         if file_pattern.startswith('/./') %}
+{%-           set file_pattern = file_pattern.replace('./', '{0}/'.format(semrel_formula)) %}
+{%-         endif %}
+{{ '{0:<{2}} {1}'.format(file_pattern, owners|join(' ') if owners is list else owners, codeowners.col_width) }}
+{%-       endfor %}
+{%-     endfor %}
+{%-   endif %}
+{%- endmacro %}
+
+{{- format_entries('global', 'everything in the repo, unless a later match takes precedence') }}
+{{- format_entries('specific_directories', 'specific directories') }}
+{{- format_entries('specific_ssf', 'files/directories related to `semantic-release`') }}
+{{- format_entries('specific_files', 'specific files') }}

--- a/ssf/files/tofs_template-formula/docs/CONTRIBUTING.rst
+++ b/ssf/files/tofs_template-formula/docs/CONTRIBUTING.rst
@@ -161,12 +161,28 @@ An example of that:
 Semantic release formulas
 -------------------------
 
-These formulas are already compatible with semantic-release:
+These formulas are already compatible with semantic-release *and* have global ``CODEOWNERS`` defined:
 
-#. `apache-formula <https://github.com/saltstack-formulas/apache-formula>`_
-#. `apt-cacher-formula <https://github.com/saltstack-formulas/apt-cacher-formula>`_
 #. `apt-formula <https://github.com/saltstack-formulas/apt-formula>`_
 #. `bind-formula <https://github.com/saltstack-formulas/bind-formula>`_
+#. `fail2ban-formula <https://github.com/saltstack-formulas/fail2ban-formula>`_
+#. `iptables-formula <https://github.com/saltstack-formulas/iptables-formula>`_
+#. `letsencrypt-formula <https://github.com/saltstack-formulas/letsencrypt-formula>`_
+#. `libvirt-formula <https://github.com/saltstack-formulas/libvirt-formula>`_
+#. `nifi-formula <https://github.com/saltstack-formulas/nifi-formula>`_
+#. `openvpn-formula <https://github.com/saltstack-formulas/openvpn-formula>`_
+#. `packages-formula <https://github.com/saltstack-formulas/packages-formula>`_
+#. `postgres-formula <https://github.com/saltstack-formulas/postgres-formula>`_
+#. `salt-formula <https://github.com/saltstack-formulas/salt-formula>`_
+#. `strongswan-formula <https://github.com/saltstack-formulas/strongswan-formula>`_
+#. `sysctl-formula <https://github.com/saltstack-formulas/sysctl-formula>`_
+#. `template-formula <https://github.com/saltstack-formulas/template-formula>`_
+#. `vault-formula <https://github.com/saltstack-formulas/vault-formula>`_
+
+These formulas are already compatible with semantic-release:
+
+16. `apache-formula <https://github.com/saltstack-formulas/apache-formula>`_
+#. `apt-cacher-formula <https://github.com/saltstack-formulas/apt-cacher-formula>`_
 #. `cert-formula <https://github.com/saltstack-formulas/cert-formula>`_
 #. `chrony-formula <https://github.com/saltstack-formulas/chrony-formula>`_
 #. `collectd-formula <https://github.com/saltstack-formulas/collectd-formula>`_
@@ -178,17 +194,14 @@ These formulas are already compatible with semantic-release:
 #. `docker-formula <https://github.com/saltstack-formulas/docker-formula>`_
 #. `epel-formula <https://github.com/saltstack-formulas/epel-formula>`_
 #. `exim-formula <https://github.com/saltstack-formulas/exim-formula>`_
-#. `fail2ban-formula <https://github.com/saltstack-formulas/fail2ban-formula>`_
 #. `firewalld-formula <https://github.com/saltstack-formulas/firewalld-formula>`_
 #. `golang-formula <https://github.com/saltstack-formulas/golang-formula>`_
 #. `grafana-formula <https://github.com/saltstack-formulas/grafana-formula>`_
 #. `hostsfile-formula <https://github.com/saltstack-formulas/hostsfile-formula>`_
 #. `icinga2-formula <https://github.com/saltstack-formulas/icinga2-formula>`_
 #. `influxdb-formula <https://github.com/saltstack-formulas/influxdb-formula>`_
-#. `iptables-formula <https://github.com/saltstack-formulas/iptables-formula>`_
 #. `iscsi-formula <https://github.com/saltstack-formulas/iscsi-formula>`_
 #. `keepalived-formula <https://github.com/saltstack-formulas/keepalived-formula>`_
-#. `letsencrypt-formula <https://github.com/saltstack-formulas/letsencrypt-formula>`_
 #. `libvirt-formula <https://github.com/saltstack-formulas/libvirt-formula>`_
 #. `locale-formula <https://github.com/saltstack-formulas/locale-formula>`_
 #. `logrotate-formula <https://github.com/saltstack-formulas/logrotate-formula>`_
@@ -197,26 +210,20 @@ These formulas are already compatible with semantic-release:
 #. `mysql-formula <https://github.com/saltstack-formulas/mysql-formula>`_
 #. `nfs-formula <https://github.com/saltstack-formulas/nfs-formula>`_
 #. `nginx-formula <https://github.com/saltstack-formulas/nginx-formula>`_
-#. `nifi-formula <https://github.com/saltstack-formulas/nifi-formula>`_
 #. `node-formula <https://github.com/saltstack-formulas/node-formula>`_
 #. `ntp-formula <https://github.com/saltstack-formulas/ntp-formula>`_
 #. `openldap-formula <https://github.com/saltstack-formulas/openldap-formula>`_
 #. `openssh-formula <https://github.com/saltstack-formulas/openssh-formula>`_
-#. `openvpn-formula <https://github.com/saltstack-formulas/openvpn-formula>`_
-#. `packages-formula <https://github.com/saltstack-formulas/packages-formula>`_
 #. `php-formula <https://github.com/saltstack-formulas/php-formula>`_
 #. `postfix-formula <https://github.com/saltstack-formulas/postfix-formula>`_
-#. `postgres-formula <https://github.com/saltstack-formulas/postgres-formula>`_
 #. `powerdns-formula <https://github.com/saltstack-formulas/powerdns-formula>`_
 #. `prometheus-formula <https://github.com/saltstack-formulas/prometheus-formula>`_
 #. `rabbitmq-formula <https://github.com/saltstack-formulas/rabbitmq-formula>`_
 #. `redis-formula <https://github.com/saltstack-formulas/redis-formula>`_
 #. `rkhunter-formula <https://github.com/saltstack-formulas/rkhunter-formula>`_
 #. `salt-formula <https://github.com/saltstack-formulas/salt-formula>`_
-#. `strongswan-formula <https://github.com/saltstack-formulas/strongswan-formula>`_
 #. `stunnel-formula <https://github.com/saltstack-formulas/stunnel-formula>`_
 #. `sudoers-formula <https://github.com/saltstack-formulas/sudoers-formula>`_
-#. `sysctl-formula <https://github.com/saltstack-formulas/sysctl-formula>`_
 #. `syslog-ng-formula <https://github.com/saltstack-formulas/syslog-ng-formula>`_
 #. `sysstat-formula <https://github.com/saltstack-formulas/sysstat-formula>`_
 #. `systemd-formula <https://github.com/saltstack-formulas/systemd-formula>`_
@@ -227,7 +234,6 @@ These formulas are already compatible with semantic-release:
 #. `ufw-formula <https://github.com/saltstack-formulas/ufw-formula>`_
 #. `users-formula <https://github.com/saltstack-formulas/users-formula>`_
 #. `varnish-formula <https://github.com/saltstack-formulas/varnish-formula>`_
-#. `vault-formula <https://github.com/saltstack-formulas/vault-formula>`_
 #. `vim-formula <https://github.com/saltstack-formulas/vim-formula>`_
 #. `vsftpd-formula <https://github.com/saltstack-formulas/vsftpd-formula>`_
 #. `zabbix-formula <https://github.com/saltstack-formulas/zabbix-formula>`_

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -313,6 +313,9 @@ ssf_node_anchors:
         .yamllint: &file__--yamllint
           <<: *file_default
           template: 'jinja'
+        CODEOWNERS: &file__CODEOWNERS
+          <<: *file_default
+          template: 'jinja'
         commitlint.config.js: &file__commitlint--config--js
           <<: *file_default
         Gemfile: &file__Gemfile
@@ -332,6 +335,11 @@ ssf_node_anchors:
 
 ssf:
   semrel_formulas:
+    # aegir:
+    #   codeowners:
+    #     entries:
+    #       global:
+    #         - '*': '@javierbertoli'
     apache:
       context:
         git:
@@ -361,6 +369,10 @@ ssf:
           - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     apt:
+      codeowners:
+        entries:
+          global:
+            - '*': '@javierbertoli'
       context:
         git:
           github:
@@ -449,7 +461,21 @@ ssf:
         formula/libtofs.jinja:
           <<: *file__formula__libtofs--jinja
           dest_file: 'formula/ng/libtofs.jinja'
+    # arvados:
+    #   codeowners:
+    #     entries:
+    #       global:
+    #         - '*': '@javierbertoli'
+    # bareos:
+    #   codeowners:
+    #     entries:
+    #       global:
+    #         - '*': '@javierbertoli'
     bind:
+      codeowners:
+        entries:
+          global:
+            - '*': '@javierbertoli'
       context:
         git:
           github:
@@ -555,6 +581,11 @@ ssf:
         platforms_matrix: *platforms_matrix_new
       semrel_files: *semrel_files_default
     cron:
+      codeowners:
+        entries:
+          specific_directories:
+            - '/./saltcheck-tests/': '@myii'
+            - '/test/': '@myii'
       context:
         git:
           github:
@@ -616,6 +647,10 @@ ssf:
         use_tofs: true
       semrel_files: *semrel_files_default
     dhcpd:
+      codeowners:
+        entries:
+          specific_directories:
+            - '/test/': '@myii'
       context:
         git:
           github:
@@ -730,6 +765,10 @@ ssf:
         use_tofs: true
       semrel_files: *semrel_files_default
     fail2ban:
+      codeowners:
+        entries:
+          global:
+            - '*': '@javierbertoli'
       context:
         git:
           github:
@@ -760,6 +799,10 @@ ssf:
           - [centos       ,   6   ,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     firewalld:
+      codeowners:
+        entries:
+          specific_directories:
+            - '/test/': '@myii'
       context:
         git:
           github:
@@ -879,6 +922,10 @@ ssf:
         platforms_matrix: *platforms_matrix_without_arch
       semrel_files: *semrel_files_default
     iptables:
+      codeowners:
+        entries:
+          global:
+            - '*': '@javierbertoli'
       context:
         git:
           github:
@@ -1022,6 +1069,10 @@ ssf:
         use_tofs: true
       semrel_files: *semrel_files_default
     letsencrypt:
+      codeowners:
+        entries:
+          global:
+            - '*': '@javierbertoli'
       context:
         git:
           github:
@@ -1101,6 +1152,10 @@ ssf:
           - [opensuse/leap,  15.1 ,   2018.3,      2,             git]
       semrel_files: *semrel_files_default
     libvirt:
+      codeowners:
+        entries:
+          global:
+            - '*': '@baby-gnu'
       context:
         git:
           github:
@@ -1278,6 +1333,10 @@ ssf:
           - [arch-base    , latest,   2018.3,      2,     loop5-loop6]
       semrel_files: *semrel_files_default
     mattermost:
+      codeowners:
+        entries:
+          global:
+            - '*': '@kjkeane'
       context:
         git:
           github:
@@ -1404,6 +1463,10 @@ ssf:
         use_tofs: true
       semrel_files: *semrel_files_default
     nifi:
+      codeowners:
+        entries:
+          global:
+            - '*': '@codeboyQ2n5ha45'
       context:
         git:
           github:
@@ -1538,6 +1601,10 @@ ssf:
               ignore: *ignore_pillar_example
       semrel_files: *semrel_files_default
     openldap:
+      codeowners:
+        entries:
+          specific_directories:
+            - '/test/': '@myii'
       context:
         git:
           github:
@@ -1595,6 +1662,10 @@ ssf:
         use_tofs: true
       semrel_files: *semrel_files_default
     openvpn:
+      codeowners:
+        entries:
+          global:
+            - '*': '@dafyddj'
       context:
         git:
           github:
@@ -1637,6 +1708,10 @@ ssf:
               - test/salt/pillar/default.sls
       semrel_files: *semrel_files_default
     packages:
+      codeowners:
+        entries:
+          global:
+            - '*': '@javierbertoli'
       context:
         git:
           github:
@@ -1835,6 +1910,12 @@ ssf:
               ignore: *ignore_pillar_example
       semrel_files: *semrel_files_default
     postgres:
+      codeowners:
+        entries:
+          global:
+            - '*':
+                - '@vutny'
+                - '@myii'
       context:
         git:
           github:
@@ -1869,6 +1950,10 @@ ssf:
               - test/salt/pillar/postgres.sls
       semrel_files: *semrel_files_default
     powerdns:
+      codeowners:
+        entries:
+          specific_directories:
+            - '/test/': '@myii'
       context:
         git:
           github:
@@ -2028,7 +2113,23 @@ ssf:
         use_cirrus_ci: true
         use_tofs: true
       semrel_files: *semrel_files_default
+    # rspamd:
+    #   codeowners:
+    #     entries:
+    #       global:
+    #         - '*': '@javierbertoli'
     salt:
+      codeowners:
+        entries:
+          global:
+            - '*': '@saltstack-formulas/wg'
+          specific_directories:
+            - '/test/': '@myii'
+          specific_files:
+            - '/./formulas.sls':
+                - '@sticky-note'
+                - '@myii'
+            - '/./pin.sls': '@hatifnatt'
       context:
         git:
           github:
@@ -2177,6 +2278,11 @@ ssf:
               - salt/osmap.yaml
       semrel_files: *semrel_files_default
     ssf:
+      codeowners:
+        entries:
+          global:
+            - '*': '@myii'
+          specific_ssf: []
       context:
         git:
           github:
@@ -2222,6 +2328,7 @@ ssf:
         .salt-lint: *file__--salt-lint
         .travis.yml: *file__--travis--yml
         .yamllint: *file__--yamllint
+        CODEOWNERS: *file__CODEOWNERS
         commitlint.config.js: *file__commitlint--config--js
         Gemfile: *file__Gemfile
         Gemfile.lock: *file__Gemfile--lock
@@ -2229,6 +2336,10 @@ ssf:
         release-rules.js: *file__release-rules--js
         release.config.js: *file__release--config--js
     stack:
+      codeowners:
+        entries:
+          global:
+            - '*': '@claudekenni'
       context:
         git:
           github:
@@ -2256,9 +2367,14 @@ ssf:
         inspec/inspec.yml: *file__inspec__inspec--yml
         inspec/README.md: *file__inspec__README--md
         .gitignore: *file__--gitignore
+        CODEOWNERS: *file__CODEOWNERS
         Gemfile: *file__Gemfile
         Gemfile.lock: *file__Gemfile--lock
     strongswan:
+      codeowners:
+        entries:
+          global:
+            - '*': '@daks'
       context:
         git:
           github:
@@ -2322,6 +2438,10 @@ ssf:
                     - .included
       semrel_files: *semrel_files_default
     sysctl:
+      codeowners:
+        entries:
+          global:
+            - '*': '@javierbertoli'
       context:
         git:
           github:
@@ -2459,6 +2579,10 @@ ssf:
         use_tofs: true
       semrel_files: *semrel_files_default
     template:
+      codeowners:
+        entries:
+          global:
+            - '*': '@saltstack-formulas/wg'
       context:
         git:
           github:
@@ -2541,6 +2665,10 @@ ssf:
         platforms_matrix: *platforms_matrix_new
       semrel_files: *semrel_files_default
     tomcat:
+      codeowners:
+        entries:
+          specific_directories:
+            - '/test/': '@myii'
       context:
         git:
           github:
@@ -2766,6 +2894,10 @@ ssf:
       #   use_tofs: true
       semrel_files: *semrel_files_default
     vault:
+      codeowners:
+        entries:
+          global:
+            - '*': '@dafyddj'
       context:
         git:
           github:
@@ -2878,6 +3010,10 @@ ssf:
                 - .sls: 'test/salt/pillar/vsftpd.sls'
       semrel_files: *semrel_files_default
     zabbix:
+      codeowners:
+        entries:
+          specific_directories:
+            - '/test/': '@myii'
       context:
         git:
           github:


### PR DESCRIPTION
A couple of formulas have already been managed while developing this:

* [`libvirt-formula`](https://github.com/saltstack-formulas/libvirt-formula/blob/e8760b7f47c507182f7235b2d3d94e4f95f0ee1b/CODEOWNERS)
* [`salt-formula`](https://github.com/saltstack-formulas/salt-formula/blob/3a46ca426b15c64c507b78d37782c45ff02c75a8/CODEOWNERS)

When no global owner is defined (which will be most of the formulas for now), the file will have a comment header at the top, which looks like this:

* [`libvirt-formula` without global owner](https://github.com/saltstack-formulas/libvirt-formula/commit/614f2e27f7de7e9f74dcbc958bb317682293b4fd)

Obviously, when this PR is merged, the file will be managed here as well.