### PR TITLE
feat(salt): adjust matrix to add `opensuse-leap-15.2`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -55,8 +55,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(kitchen): standardise structure"
-            body: '* Checked using https://github.com/myii/ssf-formula/pull/194'
+            title: "ci(kitchen+travis): adjust matrix to add '`'opensuse-leap-15.2'`'"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/195'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -169,11 +169,13 @@ platforms:
       {{- format_driver_image(os, os_ver, salt_ver, py_ver, pre_salted) }}
       {{- format_driver_prov_cmds(os, os_ver, salt_ver, py_ver, pre_salted) }}
       {{- format_driver_run_cmds(os, os_ver) }}
-    {%- if [os, os_ver] == ['opensuse/leap', 15.1] %}
-    # Workaround to avoid intermittent failures on `opensuse-leap-15.1`:
+    {%- if os == 'opensuse/leap' %}
+    {%-   if os_ver in [15.1, 15.2] %}
+    # Workaround to avoid intermittent failures on `opensuse-leap-{{ os_ver }}`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
+    {%-   endif %}
     {%- endif %}
 {%-   endif %}
 {%- endfor %}

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2968,6 +2968,7 @@ ssf:
               - [centos       ,   8   ,   3000.3,      3]
               - [centos       ,   7   ,   3000.3,      3]
               - [fedora       ,  31   ,   3000.3,      3]
+              - [opensuse/leap,  15.2 ,   3000.3,      3]
               - [opensuse/leap,  15.1 ,   3000.3,      3]
               - [amazonlinux  ,   2   ,   3000.3,      3]
             inspec_yml:
@@ -3008,8 +3009,6 @@ ssf:
               - [ubuntu       ,  16.04,   2019.2,      3]
               - [centos       ,   8   ,   2019.2,      3]
               - [centos       ,   7   ,   2019.2,      3]
-              - [fedora       ,  31   ,   2019.2,      3]
-              - [opensuse/leap,  15.1 ,   2019.2,      3]
               - [amazonlinux  ,   2   ,   2019.2,      3]
             inspec_yml:
               summary: >-
@@ -3053,6 +3052,7 @@ ssf:
           - [centos       ,   8   ,   3000.3,      3]
           - [centos       ,   7   ,   3000.3,      3]
           - [fedora       ,  31   ,   3000.3,      3]
+          - [opensuse/leap,  15.2 ,   3000.3,      3]
           - [opensuse/leap,  15.1 ,   3000.3,      3]
           - [amazonlinux  ,   2   ,   3000.3,      3]
           - [ubuntu       ,  18.04,   3000.3,      2]
@@ -3063,8 +3063,6 @@ ssf:
           - [ubuntu       ,  16.04,   2019.2,      3]
           - [centos       ,   8   ,   2019.2,      3]
           - [centos       ,   7   ,   2019.2,      3]
-          - [fedora       ,  31   ,   2019.2,      3]
-          - [opensuse/leap,  15.1 ,   2019.2,      3]
           - [amazonlinux  ,   2   ,   2019.2,      3]
           - [centos       ,   6   ,   2019.2,      2]
           - [amazonlinux  ,   1   ,   2019.2,      2]
@@ -3076,8 +3074,8 @@ ssf:
           - [centos       ,   8   ,   3000.3,      3,     v3000-py3]
           # - [centos       ,   7   ,   3000.3,      3,     v3000-py3]
           - [fedora       ,  31   ,   3000.3,      3,     v3000-py3]
-          # # Not working for `3000.X` yet
-          # # - [opensuse/leap,  15.1 ,   3000.3,      3,     v3000-py3]
+          - [opensuse/leap,  15.2 ,   3000.3,      3,     v3000-py3]
+          - [opensuse/leap,  15.1 ,   3000.3,      3,     v3000-py3]
           - [amazonlinux  ,   2   ,   3000.3,      3,     v3000-py3]
           - [ubuntu       ,  18.04,   3000.3,      2,     v3000-py2]
           # - [ubuntu       ,  16.04,   3000.3,      2,     v3000-py2]
@@ -3087,9 +3085,6 @@ ssf:
           - [ubuntu       ,  16.04,   2019.2,      3,   v201902-py3]
           # - [centos       ,   8   ,   2019.2,      3,   v201902-py3]
           - [centos       ,   7   ,   2019.2,      3,   v201902-py3]
-          # # Won't install less than `3000.X`
-          # # - [fedora       ,  31   ,   2019.2,      3,   v201902-py3]
-          - [opensuse/leap,  15.1 ,   2019.2,      3,   v201902-py3]
           # - [amazonlinux  ,   2   ,   2019.2,      3,   v201902-py3]
           - [centos       ,   6   ,   2019.2,      2,   v201902-py2]
           # # States don't complete


### PR DESCRIPTION
Includes:

* fix(kitchen): apply `SCP` workaround for `opensuse-leap-15.2` as well