### PR TITLE
feat(suricata): finalise structure after transfer to main org

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -55,8 +55,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore: use standardised structure"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/231'
+            title: "chore: finalise structure after transfer to main org"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/232'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3696,7 +3696,6 @@ ssf:
               - '*': '@alias454'
         git:
           github:
-            owner: 'alias454'
             repo: 'suricata-formula'
         inspec_suites_kitchen:
           0:
@@ -3709,6 +3708,7 @@ ssf:
                 - .sls: 'test/salt/pillar/default.sls'
         platforms:
           # Effectively from `*platforms_new`
+          # Based on `saltimages` at the time of this comment
           # [os           , os_ver, salt_ver, py_ver]
           - [ubuntu       ,  20.04,   master,      3]
           - [ubuntu       ,  18.04,   master,      3]
@@ -3730,22 +3730,10 @@ ssf:
         platforms_matrix:
           # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
           - [ubuntu       ,  20.04,   master,      3,         default]
-          # - [ubuntu       ,  18.04,   master,      3,         default]
-          # - [centos       ,   8   ,   master,      3,         default]
-          # - [ubuntu       ,  20.04,   3001  ,      3,         default]
-          # - [ubuntu       ,  18.04,   3001  ,      3,         default]
           - [centos       ,   8   ,   3001  ,      3,         default]
-          # - [centos       ,   7   ,   3001  ,      3,         default]
           - [ubuntu       ,  18.04,   3000.3,      3,         default]
-          # - [centos       ,   8   ,   3000.3,      3,         default]
-          # - [centos       ,   7   ,   3000.3,      3,         default]
-          # - [ubuntu       ,  18.04,   3000.3,      2,         default]
           - [ubuntu       ,  16.04,   3000.3,      2,         default]
-          # - [ubuntu       ,  18.04,   2019.2,      3,         default]
-          # - [ubuntu       ,  16.04,   2019.2,      3,         default]
-          # - [centos       ,   8   ,   2019.2,      3,         default]
           - [centos       ,   7   ,   2019.2,      3,         default]
-          # # - [centos       ,   6   ,   2019.2,      2,         default]
         yamllint:
           ignore:
             additional:


### PR DESCRIPTION
* Would only make a difference if Zulip had been configured for the
  previous formula location
* Update `docs/README.rst` in the actual formula to finalise the badges
* Use this PR as a general clean-up of the formula structure here in the
  `ssf-formula`