### PR TITLE
feat(pre-commit): add `pre-commit`

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -15,12 +15,13 @@ ignore: |
   test/**/states/**/*.sls
   .kitchen/
   ssf/files/default/.cirrus.yml
+  ssf/files/default/.pre-commit-config.yaml
   ssf/files/default/.rubocop.yml
   ssf/files/default/.salt-lint
   ssf/files/default/.travis.yml
   ssf/files/default/.yamllint
-  ssf/files/default/kitchen.yml
   ssf/files/default/inspec/inspec.yml
+  ssf/files/default/kitchen.yml
   ssf/files/tofs_arvados-formula/.travis.yml
   ssf/files/tofs_ssf-formula/.yamllint
 

--- a/pillar.example
+++ b/pillar.example
@@ -174,6 +174,7 @@ ssf:
       - zabbix
     semrel_files:
       - .github/workflows/commitlint.yml
+      - bin/install-hooks
       - bin/kitchen
       - docs/CONTRIBUTING.rst
       - docs/TOFS_pattern.rst
@@ -183,6 +184,8 @@ ssf:
       - inspec/README.md
       - .gitignore
       - .cirrus.yml
+      - .pre-commit-config.yaml
+      - .rstcheck.cfg
       - .rubocop.yml
       - .salt-lint
       - .travis.yml

--- a/ssf/config/formulas.sls
+++ b/ssf/config/formulas.sls
@@ -104,7 +104,7 @@ prepare-git-branch-for-{{ formula }}:
 {%-           if (semrel_file == '.cirrus.yml' and not use_cirrus_ci) or
                  (semrel_file == 'formula/libsaltcli.jinja' and not use_libsaltcli) or
                  (semrel_file in ['docs/TOFS_pattern.rst', 'formula/libtofs.jinja'] and not use_tofs) or
-                 (semrel_file in ['docs/CONTRIBUTING.rst'] and formula not in ['.github'])
+                 (semrel_file in ['docs/CONTRIBUTING.rst'] and formula not in ['.github', 'ssf-formula'])
 %}
 {%-             set add_or_rm = ['rm', 'remove', 'absent'] %}
 {%-           endif %}

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -17,6 +17,7 @@ ssf_node_anchors:
             specific_directories: []
             specific_ssf:
               - '/.github/workflows/': '@saltstack-formulas/ssf'
+              - '/bin/install-hooks': '@saltstack-formulas/ssf'
               - '/bin/kitchen': '@saltstack-formulas/ssf'
               - '/docs/AUTHORS.rst': '@saltstack-formulas/ssf'
               - '/docs/CHANGELOG.rst': '@saltstack-formulas/ssf'
@@ -27,6 +28,8 @@ ssf_node_anchors:
               - '/test/integration/**/README.md': '@saltstack-formulas/ssf'
               - '/.gitignore': '@saltstack-formulas/ssf'
               - '/.cirrus.yml': '@saltstack-formulas/ssf'
+              - '/.pre-commit-config.yaml': '@saltstack-formulas/ssf'
+              - '/.rstcheck.cfg': '@saltstack-formulas/ssf'
               - '/.rubocop.yml': '@saltstack-formulas/ssf'
               - '/.salt-lint': '@saltstack-formulas/ssf'
               - '/.travis.yml': '@saltstack-formulas/ssf'

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -58,8 +58,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore: standardise structure [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/261'
+            title: "ci(pre-commit): add to formula [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/259'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/.pre-commit-config.yaml
+++ b/ssf/files/default/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+default_stages: [commit]
+repos:
+  - repo: https://github.com/dafyddj/commitlint-pre-commit-hook
+    rev: v2.3.0
+    hooks:
+      - id: commitlint
+        name: Check commit message using commitlint
+        description: Lint commit message against @commitlint/config-conventional rules
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional@8.3.4']
+      - id: commitlint-travis
+        stages: [manual]
+        additional_dependencies: ['@commitlint/config-conventional@8.3.4']
+        always_run: true
+  - repo: https://github.com/adithyabsk/mirrors-rubocop
+    rev: v0.91.0
+    hooks:
+      - id: rubocop
+        name: Check Ruby files with rubocop
+        args: [--debug]
+        always_run: true
+        pass_filenames: false
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.3
+    hooks:
+      - id: shellcheck
+        name: Check shell scripts with shellcheck
+        files: ^.*\.(sh|bash|ksh)$
+        types: []
+        args: []
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.23.0
+    hooks:
+      - id: yamllint
+        name: Check YAML syntax with yamllint
+        args: [--strict, '.']
+        always_run: true
+        pass_filenames: false
+  - repo: https://github.com/warpnet/salt-lint
+    rev: v0.3.0
+    hooks:
+      - id: salt-lint
+        name: Check Salt files using salt-lint
+        files: ^.*\.(sls|jinja|j2|tmpl|tst)$
+  - repo: https://github.com/myint/rstcheck
+    rev: 3f929574
+    hooks:
+      - id: rstcheck
+        name: Check reST files using rstcheck
+        args: [--report=warning]

--- a/ssf/files/default/.pre-commit-config.yaml
+++ b/ssf/files/default/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
         stages: [manual]
         additional_dependencies: ['@commitlint/config-conventional@8.3.4']
         always_run: true
+  {%- if travis.use_single_job_for_linters %}
   - repo: https://github.com/adithyabsk/mirrors-rubocop
     rev: v0.91.0
     hooks:
@@ -25,6 +26,7 @@ repos:
         args: [--debug]
         always_run: true
         pass_filenames: false
+  {%- endif %}
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.3
     hooks:
@@ -47,9 +49,9 @@ repos:
       - id: salt-lint
         name: Check Salt files using salt-lint
         files: ^.*\.(sls|jinja|j2|tmpl|tst)$
-  - repo: https://github.com/myint/rstcheck
-    rev: 3f929574
-    hooks:
-      - id: rstcheck
-        name: Check reST files using rstcheck
-        args: [--report=warning]
+#   - repo: https://github.com/myint/rstcheck
+#     rev: 3f929574
+#     hooks:
+#       - id: rstcheck
+#         name: Check reST files using rstcheck
+#         args: [--report=warning]

--- a/ssf/files/default/.rstcheck.cfg
+++ b/ssf/files/default/.rstcheck.cfg
@@ -1,0 +1,3 @@
+[rstcheck]
+report=error
+ignore_language=rst

--- a/ssf/files/default/.travis.yml
+++ b/ssf/files/default/.travis.yml
@@ -114,11 +114,6 @@ jobs:
     {{ comment_linters }}
     - language: 'node_js'
       node_js: 'lts/*'
-      {%- if semrel_formula in ['template'] %}
-      cache:
-        directories:
-          - $HOME/.cache/pre-commit
-      {%- endif %}
       env: 'Lint'
       name: '{{ name_linters }}'
       before_install: 'skip'
@@ -149,12 +144,19 @@ jobs:
         {#- Note: `--verbose` doesn't work yet, upstream issue created:          #}
         {#-   - https://github.com/conventional-changelog/commitlint/issues/1695 #}
         - commitlint-travis{{- ' --verbose' if semrel_formula == 'ssf' else '' }}
-        {%- if semrel_formula in ['template'] %}
+    # Run `pre-commit` linters in a single job
+    - language: 'python'
+      env: 'Lint_pre-commit'
+      name: 'Lint: pre-commit'
+      before_install: 'skip'
+      cache:
+        directories:
+          - $HOME/.cache/pre-commit
+      script:
         # Install and run `pre-commit`
-        - pip install pre-commit
-        - pre-commit run --all-files --verbose
-        - pre-commit run --hook-stage manual --verbose commitlint-travis
-        {%- endif %}
+        - {{ pip_cmd }} install pre-commit==2.7.1
+        - pre-commit run --all-files --color always --verbose
+        - pre-commit run --color always --hook-stage manual --verbose commitlint-travis
     {%- if not travis.use_single_job_for_linters %}
     # Run the `rubocop` linter in a separate job that is allowed to fail
     # Once these lint errors are fixed, this can be merged into a single job

--- a/ssf/files/default/.travis.yml
+++ b/ssf/files/default/.travis.yml
@@ -144,6 +144,19 @@ jobs:
         {#- Note: `--verbose` doesn't work yet, upstream issue created:          #}
         {#-   - https://github.com/conventional-changelog/commitlint/issues/1695 #}
         - commitlint-travis{{- ' --verbose' if semrel_formula == 'ssf' else '' }}
+
+    {%- if not travis.use_single_job_for_linters %}
+    # Run the `rubocop` linter in a separate job that is allowed to fail
+    # Once these lint errors are fixed, this can be merged into a single job
+    - language: node_js
+      node_js: lts/*
+      env: Lint_rubocop
+      name: 'Lint: rubocop'
+      before_install: skip
+      script:
+        {{-   format_rubocop_linter() }}
+    {%- endif %}
+
     # Run `pre-commit` linters in a single job
     - language: 'python'
       env: 'Lint_pre-commit'
@@ -157,17 +170,6 @@ jobs:
         - {{ pip_cmd }} install pre-commit==2.7.1
         - pre-commit run --all-files --color always --verbose
         - pre-commit run --color always --hook-stage manual --verbose commitlint-travis
-    {%- if not travis.use_single_job_for_linters %}
-    # Run the `rubocop` linter in a separate job that is allowed to fail
-    # Once these lint errors are fixed, this can be merged into a single job
-    - language: node_js
-      node_js: lts/*
-      env: Lint_rubocop
-      name: 'Lint: rubocop'
-      before_install: skip
-      script:
-        {{-   format_rubocop_linter() }}
-    {%- endif %}
 
     {%- if platforms and not use_cirrus_ci %}
 

--- a/ssf/files/default/bin/install-hooks
+++ b/ssf/files/default/bin/install-hooks
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -o nounset # Treat unset variables as an error and immediately exit
+set -o errexit # If a command fails exit the whole script
+
+if [ "${DEBUG:-false}" = "true" ]; then
+  set -x # Run the entire script in debug mode
+fi
+
+if ! command -v pre-commit >/dev/null 2>&1; then
+  echo "pre-commit not found: please install or check your PATH" >&2
+  echo "See https://pre-commit.com/#installation" >&2
+  exit 1
+fi
+
+pre-commit install --install-hooks
+pre-commit install --hook-type commit-msg --install-hooks

--- a/ssf/files/tofs_.github/docs/CONTRIBUTING.rst
+++ b/ssf/files/tofs_.github/docs/CONTRIBUTING.rst
@@ -55,6 +55,22 @@ So based on the example above:
 * The ``(scope):`` will be shown in bold text without the brackets.
 * The ``subject`` follows the ``scope`` as standard text.
 
+pre-commit
+^^^^^^^^^^
+
+`pre-commit <https://pre-commit.com/>`_ is configured for this formula, which you may
+optionally use to ease the steps involved in submitting your changes, including
+checking the formatting of your commit messages.
+
+First install  the ``pre-commit`` package manager locally using the appropriate
+`method <https://pre-commit.com/#installation>`_, then run ``bin/install-hooks`` in the
+formula's root directory and now ``pre-commit`` will run automatically on each
+``git commit``. ::
+
+  $ bin/install-hooks
+  pre-commit installed at .git/hooks/pre-commit
+  pre-commit installed at .git/hooks/commit-msg
+
 Linting commit messages in Travis CI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/ssf/files/tofs_arvados-formula/.travis.yml
+++ b/ssf/files/tofs_arvados-formula/.travis.yml
@@ -55,6 +55,20 @@ jobs:
                    @commitlint/travis-cli
         - commitlint-travis
 
+    # Run `pre-commit` linters in a single job
+    - language: 'python'
+      env: 'Lint_pre-commit'
+      name: 'Lint: pre-commit'
+      before_install: 'skip'
+      cache:
+        directories:
+          - $HOME/.cache/pre-commit
+      script:
+        # Install and run `pre-commit`
+        - pip install pre-commit==2.7.1
+        - pre-commit run --all-files --color always --verbose
+        - pre-commit run --color always --hook-stage manual --verbose commitlint-travis
+
     ## Define the rest of the matrix based on Kitchen testing
     # Make sure the instances listed below match up with
     # the `platforms` defined in `kitchen.yml`

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -537,6 +537,7 @@ ssf_node_anchors:
           template: 'jinja'
         .pre-commit-config.yaml: &file__--pre-commit-config--yaml
           <<: *file_default
+          template: 'jinja'
         .rstcheck.cfg: &file__--rstcheck--cfg
           <<: *file_default
         .rubocop.yml: &file__--rubocop--yml
@@ -4138,12 +4139,13 @@ ssf:
           ignore:
             additional:
               - ssf/files/default/.cirrus.yml
+              - ssf/files/default/.pre-commit-config.yaml
               - ssf/files/default/.rubocop.yml
               - ssf/files/default/.salt-lint
               - ssf/files/default/.travis.yml
               - ssf/files/default/.yamllint
-              - ssf/files/default/kitchen.yml
               - ssf/files/default/inspec/inspec.yml
+              - ssf/files/default/kitchen.yml
               - ssf/files/tofs_arvados-formula/.travis.yml
               - ssf/files/tofs_ssf-formula/.yamllint
           rules:
@@ -4153,10 +4155,13 @@ ssf:
                 - ssf/formulas.yaml
       semrel_files:
         .github/workflows/commitlint.yml: *file__--github__workflows__commitlint--yml
+        bin/install-hooks: *file__bin__install-hooks
         docs/CONTRIBUTING.rst: *file__docs__CONTRIBUTING--rst
         docs/TOFS_pattern.rst: *file__docs__TOFS_pattern--rst
         formula/libtofs.jinja: *file__formula__libtofs--jinja
         .gitignore: *file__--gitignore
+        .pre-commit-config.yaml: *file__--pre-commit-config--yaml
+        .rstcheck.cfg: *file__--rstcheck--cfg
         .rubocop.yml: *file__--rubocop--yml
         .salt-lint: *file__--salt-lint
         .travis.yml: *file__--travis--yml

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -510,6 +510,9 @@ ssf_node_anchors:
       semrel_files: &semrel_files_default
         .github/workflows/commitlint.yml: &file__--github__workflows__commitlint--yml
           <<: *file_default
+        bin/install-hooks: &file__bin__install-hooks
+          <<: *file_default
+          mode: 755
         bin/kitchen: &file__bin__kitchen
           <<: *file_default
           mode: 755
@@ -532,6 +535,10 @@ ssf_node_anchors:
         .cirrus.yml: &file__--cirrus--yml
           <<: *file_default
           template: 'jinja'
+        .pre-commit-config.yaml: &file__--pre-commit-config--yaml
+          <<: *file_default
+        .rstcheck.cfg: &file__--rstcheck--cfg
+          <<: *file_default
         .rubocop.yml: &file__--rubocop--yml
           <<: *file_default
           template: 'jinja'


### PR DESCRIPTION
Making a start on this.

Think rolling this out is best done in stages:

- keep `yamllint` files and ignores in `.yamllint`
- roll out to all formulas
- remove standalone lint jobs
- move `yamllint` files and ignores from `.yamllint` to `.pre-commit-config.yaml`; and
  - implement `shellcheck.exclude_paths` in `.pre-commit-config.yaml`

Things to resolve in this PR:

- [x] ~~start formula by formula?~~
- [x] handle `use_single_job_for_linters:  false`
- [x] what about docs?