### PR TITLE
feat(gitlab-ci): add `rubocop` linter (with `allow_failure`)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@
   image_precommit: &image_precommit
     name: 'myii/ssf-pre-commit:2.9.2'
     entrypoint: ['/bin/bash', '-c']
+  image_rubocop: &image_rubocop 'pipelinecomponents/rubocop:latest'
   image_semantic-release: &image_semanticrelease 'myii/ssf-semantic-release:15.14'
 
 ###############################################################################
@@ -66,6 +67,19 @@ pre-commit:
       - '${PRE_COMMIT_HOME}'
   script:
     - 'pre-commit run --all-files --color always --verbose'
+
+# Use a separate job for `rubocop` other than the one potentially run by `pre-commit`
+# - The `pre-commit` check will only be available for formulas that pass the default
+#   `rubocop` check -- and must continue to do so
+# - This job is allowed to fail, so can be used for all formulas
+# - Furthermore, this job uses all of the latest `rubocop` features & cops,
+#   which will help when upgrading the `rubocop` linter used in `pre-commit`
+rubocop:
+  allow_failure: true
+  stage: *stage_lint
+  image: *image_rubocop
+  script:
+    - 'rubocop -d -P -S --enable-pending-cops'
 
 ###############################################################################
 # `release` stage: `semantic-release`

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -59,8 +59,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "fix(osfingermap): reinstate values for '`'Debian-9'`' after regression"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/276'
+            title: "ci(gitlab-ci): add '`'rubocop'`' linter (with '`'allow_failure'`') [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/277'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/.gitlab-ci.yml
+++ b/ssf/files/default/.gitlab-ci.yml
@@ -32,6 +32,7 @@
   image_precommit: &image_precommit
     name: 'myii/ssf-pre-commit:2.9.2'
     entrypoint: ['/bin/bash', '-c']
+  image_rubocop: &image_rubocop 'pipelinecomponents/rubocop:latest'
   image_semantic-release: &image_semanticrelease 'myii/ssf-semantic-release:15.14'
   {%- if semrel_formula != 'ssf' %}
   # `services`
@@ -101,6 +102,19 @@ pre-commit:
       - '${PRE_COMMIT_HOME}'
   script:
     - 'pre-commit run --all-files --color always --verbose'
+
+# Use a separate job for `rubocop` other than the one potentially run by `pre-commit`
+# - The `pre-commit` check will only be available for formulas that pass the default
+#   `rubocop` check -- and must continue to do so
+# - This job is allowed to fail, so can be used for all formulas
+# - Furthermore, this job uses all of the latest `rubocop` features & cops,
+#   which will help when upgrading the `rubocop` linter used in `pre-commit`
+rubocop:
+  allow_failure: true
+  stage: *stage_lint
+  image: *image_rubocop
+  script:
+    - 'rubocop -d -P -S --enable-pending-cops'
 
 {%- if platforms and not use_cirrus_ci %}
 


### PR DESCRIPTION
Use a separate job for `rubocop` other than the one potentially run by `pre-commit`
- The `pre-commit` check will only be available for formulas that pass the default
  `rubocop` check -- and must continue to do so
- This job is allowed to fail, so can be used for all formulas
- Furthermore, this job uses all of the latest `rubocop` features & cops,
  which will help when upgrading the `rubocop` linter used in `pre-commit`