### PR TITLE
feat(commitlint): ensure `upstream/master` uses main repo URL

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,8 @@ commitlint:
   image: *image_commitlint
   script:
     # Add `upstream` remote to get access to `upstream/master`
-    - 'git remote add upstream ${CI_PROJECT_URL}.git'
+    - 'git remote add upstream
+       https://gitlab.com/myii/ssf-formula.git'
     - 'git fetch --all'
     # Set default commit hashes for `--from` and `--to`
     - 'export COMMITLINT_FROM="$(git merge-base upstream/master HEAD)"'

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -59,8 +59,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(gitlab-ci): add '`'rubocop'`' linter (with '`'allow_failure'`') [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/277'
+            title: "ci(commitlint): ensure '`'upstream/master'`' uses main repo URL [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/278'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/.gitlab-ci.yml
+++ b/ssf/files/default/.gitlab-ci.yml
@@ -71,7 +71,8 @@ commitlint:
   image: *image_commitlint
   script:
     # Add `upstream` remote to get access to `upstream/master`
-    - 'git remote add upstream ${CI_PROJECT_URL}.git'
+    - 'git remote add upstream
+       https://gitlab.com/{{ gitlab.owner }}/{{ gitlab.repo or formula }}.git'
     - 'git fetch --all'
     # Set default commit hashes for `--from` and `--to`
     - 'export COMMITLINT_FROM="$(git merge-base upstream/master HEAD)"'


### PR DESCRIPTION
Avoid using `${CI_PROJECT_URL}` (the local repo's URL) since that leads
to `upstream/master` only pointing to the local repo's `master` branch,
which could be many commits behind, resulting in spurious `commitlint`
failures.