### PR TITLE
feat(_mapdata): manage `map.jinja` verification (replace `yaml_dump`)

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -1136,7 +1136,15 @@ ssf:
             <<: *isk_suite_default
             name: 'gentoo'
     timezone: *formula_default
-    tomcat: *formula_default
+    tomcat:
+      <<: *formula_default
+      context:
+        <<: *context_default
+        inspec_suites_kitchen:
+          <<: *isk_default
+          1:
+            <<: *isk_suite_default
+            name: 'share'
     ufw:
       <<: *formula_default
       context:

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -1028,7 +1028,15 @@ ssf:
             name: 'suse'
     postfix: *formula_default
     postgres: *formula_default
-    powerdns: *formula_default
+    powerdns:
+      <<: *formula_default
+      context:
+        <<: *context_default
+        inspec_suites_kitchen:
+          <<: *isk_default
+          1:
+            <<: *isk_suite_default
+            name: 'share'
     proftpd:
       <<: *formula_default
       context:

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -648,7 +648,15 @@ ssf:
           0:
             <<: *isk_suite_default
             name: 'ubuntu'
-    dhcpd: *formula_default
+    dhcpd:
+      <<: *formula_default
+      context:
+        <<: *context_default
+        inspec_suites_kitchen:
+          <<: *isk_default
+          1:
+            <<: *isk_suite_default
+            name: 'share'
     django: *formula_default
     docker:
       <<: *formula_default

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -691,7 +691,15 @@ ssf:
     epel: *formula_default
     exim: *formula_default
     fail2ban: *formula_default
-    firewalld: *formula_default
+    firewalld:
+      <<: *formula_default
+      context:
+        <<: *context_default
+        inspec_suites_kitchen:
+          <<: *isk_default
+          1:
+            <<: *isk_suite_default
+            name: 'share'
     golang:
       <<: *formula_default
       context:

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -63,7 +63,7 @@ ssf_node_anchors:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
             title: "test(map): verify '`'map.jinja'`' dump using '`'_mapdata'`' state"
-            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/285'
+            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/286'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -4957,10 +4957,6 @@ ssf:
       semrel_files: *semrel_files_default
     tomcat:
       context:
-        codeowners:
-          entries:
-            specific_directories:
-              - '/test/': '@myii'
         git:
           github:
             repo: 'tomcat-formula'
@@ -4969,17 +4965,14 @@ ssf:
             driver:
               hostname: 'example.net'
             inspec_yml:
+              depends: *depends_on_suite_share
               summary: >-
                 Verify that the tomcat formula is setup and configured correctly
-            provisioner:
-              dependencies:
-                - name: 'comparison_files'
-                  path: './test/salt'
               # pillars_from_files:
               #   - .sls: 'test/salt/pillar/default.sls'
               state_top:
                 - '*':
-                    - .yaml_dump
+                    - ._mapdata
                     - .
                     - .native
                     - .config
@@ -4988,6 +4981,10 @@ ssf:
                     - .expires
                     - .context
                     - .cluster
+          1: *inspec_suites_kitchen__share_suite
+        map_jinja:
+          verification:
+            import: ['tomcat']
         platforms: *platforms_new
         platforms_matrix:
           # Similar to `*platforms_matrix_without_arch_new` which will be
@@ -5016,14 +5013,11 @@ ssf:
             Lint/EmptyWhen:
               Exclude:
                 - 'test/integration/default/controls/config_spec.rb'
-            Style/FormatStringToken:
-              Exclude:
-                - 'test/integration/default/controls/yaml_dump_spec.rb'
         yamllint:
           ignore:
             additional:
               - tomcat/osfamilymap.yaml
-      semrel_files: *semrel_files_default
+      semrel_files: *semrel_files_inc_map_jinja_verifier
     ufw:
       context:
         git:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3717,14 +3717,13 @@ ssf:
           entries:
             global:
               - '*': '@sticky-note'
-            specific_directories:
-              - '/test/': '@myii'
         git:
           github:
             repo: 'powerdns-formula'
         inspec_suites_kitchen:
           0:
             inspec_yml:
+              depends: *depends_on_suite_share
               summary: >-
                 Verify that the powerdns formula is setup and configured correctly
             provisioner:
@@ -3732,9 +3731,13 @@ ssf:
                 - .sls: 'test/salt/pillar/default.sls'
               state_top:
                 - '*':
-                    - .yaml_dump
+                    - ._mapdata
                     - .config
                     - .backend-sqlite3
+          1: *inspec_suites_kitchen__share_suite
+        map_jinja:
+          verification:
+            import: ['powerdns']
         platforms: *platforms_new
         platforms_matrix:
           # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
@@ -3750,7 +3753,7 @@ ssf:
           ignore:
             additional:
               - sls.example
-      semrel_files: *semrel_files_default
+      semrel_files: *semrel_files_inc_map_jinja_verifier
     proftpd:
       context:
         codeowners:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -4966,6 +4966,8 @@ ssf:
             repo: 'tomcat-formula'
         inspec_suites_kitchen:
           0:
+            driver:
+              hostname: 'example.net'
             inspec_yml:
               summary: >-
                 Verify that the tomcat formula is setup and configured correctly

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1304,21 +1304,24 @@ ssf:
           entries:
             global:
               - '*': '@sticky-note'
-            specific_directories:
-              - '/test/': '@myii'
         git:
           github:
             repo: 'dhcpd-formula'
         inspec_suites_kitchen:
           0:
             inspec_yml:
+              depends: *depends_on_suite_share
               summary: >-
                 Verify that the dhcpd formula is setup and configured correctly
             provisioner:
               state_top:
                 - '*':
-                    - .yaml_dump
+                    - ._mapdata
                     - .config
+          1: *inspec_suites_kitchen__share_suite
+        map_jinja:
+          verification:
+            import: ['dhcpd']
         platforms: *platforms_new
         platforms_matrix:
           # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
@@ -1332,7 +1335,7 @@ ssf:
           # - [centos       ,    7   ,   2019.2,      3,         default]
           # # - [centos       ,    6   ,   2019.2,      2,         default]
           # - [arch-base    ,  latest,   2019.2,      2,         default]
-      semrel_files: *semrel_files_default
+      semrel_files: *semrel_files_inc_map_jinja_verifier
     django:
       context:
         git:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1524,23 +1524,24 @@ ssf:
       semrel_files: *semrel_files_default
     firewalld:
       context:
-        codeowners:
-          entries:
-            specific_directories:
-              - '/test/': '@myii'
         git:
           github:
             repo: 'firewalld-formula'
         inspec_suites_kitchen:
           0:
             inspec_yml:
+              depends: *depends_on_suite_share
               summary: >-
                 Verify that the firewalld formula is setup and configured correctly
             provisioner:
               state_top:
                 - '*':
-                    - .yaml_dump
+                    - ._mapdata
                     - .
+          1: *inspec_suites_kitchen__share_suite
+        map_jinja:
+          verification:
+            import: ['firewalld']
         platforms_matrix:
           # [os           , os_ver, salt_ver, py_ver,    inspec_suite]
           - [ubuntu       ,   18.04,   master,      3,         default]
@@ -1550,7 +1551,7 @@ ssf:
           - [opensuse/leap,   15.1 ,   2018.3,      2,         default]
           - [arch-base    ,  latest,   2018.3,      2,         default]
           # - [ubuntu       ,   16.04,   2017.7,      2,         default]
-      semrel_files: *semrel_files_default
+      semrel_files: *semrel_files_inc_map_jinja_verifier
     golang:
       context:
         codeowners:


### PR DESCRIPTION
Establish the standard method for formulas, replacing the initial version that was used (i.e. `yaml_dump`).