### PR TITLE
feat(saltimages): update with latest changes from `salt-image-builder`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -62,8 +62,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "fix(_mapdata): ensure map data is directly under '`'values'`'"
-            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/287'
+            title: "ci(kitchen+gitlab): update for new pre-salted images"
+            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/288'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'
@@ -323,6 +323,7 @@ ssf:
     # - [fedora       ,   33   ,   tiamat,      3]  # fedo-33.0-tiamat-py3
     # - [fedora       ,   32   ,   tiamat,      3]  # fedo-32.0-tiamat-py3
     # - [opensuse/leap,   15.2 ,   tiamat,      3]  # opsu-15.2-tiamat-py3
+    # - [opensuse/tmbl,  latest,   tiamat,      3]  # opsu-tmbl-tiamat-py3
     - [amazonlinux  ,    2   ,   tiamat,      3]  # amaz-02.0-tiamat-py3
     - [oraclelinux  ,    8   ,   tiamat,      3]  # orac-08.0-tiamat-py3
     - [oraclelinux  ,    7   ,   tiamat,      3]  # orac-07.0-tiamat-py3
@@ -338,6 +339,7 @@ ssf:
     - [fedora       ,   33   ,   master,      3]  # fedo-33.0-master-py3
     - [fedora       ,   32   ,   master,      3]  # fedo-32.0-master-py3
     - [opensuse/leap,   15.2 ,   master,      3]  # opsu-15.2-master-py3
+    - [opensuse/tmbl,  latest,   master,      3]  # opsu-tmbl-master-py3
     - [amazonlinux  ,    2   ,   master,      3]  # amaz-02.0-master-py3
     - [oraclelinux  ,    8   ,   master,      3]  # orac-08.0-master-py3
     # # Fails due to dependency issues, probably ignore permanently
@@ -356,6 +358,7 @@ ssf:
     - [fedora       ,   33   ,   3002.2,      3]  # fedo-33.0-3002.2-py3
     - [fedora       ,   32   ,   3002.2,      3]  # fedo-32.0-3002.2-py3
     - [opensuse/leap,   15.2 ,   3002.2,      3]  # opsu-15.2-3002.2-py3
+    - [opensuse/tmbl,  latest,   3002.2,      3]  # opsu-tmbl-3002.2-py3
     - [amazonlinux  ,    2   ,   3002.2,      3]  # amaz-02.0-3002.2-py3
     - [oraclelinux  ,    8   ,   3002.2,      3]  # orac-08.0-3002.2-py3
     - [oraclelinux  ,    7   ,   3002.2,      3]  # orac-07.0-3002.2-py3
@@ -374,6 +377,7 @@ ssf:
     - [fedora       ,   33   ,   3001.4,      3]  # fedo-33.0-3001.4-py3
     - [fedora       ,   32   ,   3001.4,      3]  # fedo-32.0-3001.4-py3
     - [opensuse/leap,   15.2 ,   3001.4,      3]  # opsu-15.2-3001.4-py3
+    - [opensuse/tmbl,  latest,   3001.4,      3]  # opsu-tmbl-3001.4-py3
     - [amazonlinux  ,    2   ,   3001.4,      3]  # amaz-02.0-3001.4-py3
     - [oraclelinux  ,    8   ,   3001.4,      3]  # orac-08.0-3001.4-py3
     - [oraclelinux  ,    7   ,   3001.4,      3]  # orac-07.0-3001.4-py3

--- a/ssf/files/default/inspec/README.md
+++ b/ssf/files/default/inspec/README.md
@@ -14,10 +14,11 @@ The `system` library provides easy access to system dependent information:
 - `system.platform`: based on `inspec.platform`, modify to values that are more consistent from a SaltStack perspective
   - `system.platform[:family]` provide a family name for Arch and Gentoo
   - `system.platform[:name]` append `linux` to both `amazon` and `oracle`; ensure Windows platforms are resolved as simply `windows`
-  - `system.platform[:release]` tweak Arch, Amazon Linux, Gentoo and Windows:
+  - `system.platform[:release]` tweak Arch, Amazon Linux, Gentoo, openSUSE and Windows:
     - `Arch` is always `base-latest`
     - `Amazon Linux` release `2018` is resolved as `1`
     - `Gentoo` release is trimmed to its major version number and then the init system is appended (i.e. `sysv` or `sysd`)
+    - `openSUSE` is resolved as `tumbleweed` if the `platform[:release]` is in date format
     - `Windows` uses the widely-used release number (e.g. `8.1` or `2019-server`) in place of the actual system release version
   - `system.platform[:finger]` is the concatenation of the name and the major release number (except for Ubuntu, which gives `ubuntu-20.04` for example)
 {%- else %}

--- a/ssf/files/default/inspec/libraries/system.rb
+++ b/ssf/files/default/inspec/libraries/system.rb
@@ -45,7 +45,7 @@ class SystemResource < Inspec.resource(1)
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
   def build_platform_release
     case inspec.platform[:name]
     when 'amazon'
@@ -55,6 +55,10 @@ class SystemResource < Inspec.resource(1)
       'base-latest'
     when 'gentoo'
       "#{inspec.platform[:release].split('.')[0]}-#{derive_gentoo_init_system}"
+    when 'opensuse'
+      # rubocop:disable Style/NumericLiterals,Layout/LineLength
+      inspec.platform[:release].to_i > 20210101 ? 'tumbleweed' : inspec.platform[:release]
+      # rubocop:enable Style/NumericLiterals,Layout/LineLength
     when 'windows_8.1_pro'
       '8.1'
     when 'windows_server_2019_datacenter'
@@ -63,15 +67,10 @@ class SystemResource < Inspec.resource(1)
       inspec.platform[:release]
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
 
   def derive_gentoo_init_system
-    case inspec.command('systemctl').exist?
-    when true
-      'sysd'
-    else
-      'sysv'
-    end
+    inspec.command('systemctl').exist? ? 'sysd' : 'sysv'
   end
 
   def build_platform_finger

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -54,7 +54,7 @@
 {%-     if not pre_salted %}
 image: {{ os }}:{{ os_ver }}
 {%-     else %}
-image: {{ 'saltimages' if [os, os_ver, salt_ver, py_ver] in saltimages else 'netmanagers' }}/salt-{{ salt_ver }}-py{{ py_ver }}:{{ os | replace('/', '-') }}-{{ os_ver }}
+image: {{ 'saltimages' if [os, os_ver, salt_ver, py_ver] in saltimages else 'netmanagers' }}/salt-{{ salt_ver }}-py{{ py_ver }}:{{ os | replace('/', '-') | replace('tmbl', 'tumbleweed') }}-{{ os_ver }}
 {%-     endif %}
 {%-   endfilter %}
 {%- endmacro %}
@@ -83,7 +83,7 @@ image: {{ 'saltimages' if [os, os_ver, salt_ver, py_ver] in saltimages else 'net
 {%-         if os in ['debian', 'ubuntu'] %}
 {%-           do prov_cmds.append('# https://github.com/saltstack/salt/issues/39314') %}
 {%-           do prov_cmds.append('- apt-get remove python-boto3 -y') %}
-{%-         elif os == 'opensuse/leap' %}
+{%-         elif os.startswith('opensuse') %}
 {%-           do prov_cmds.append('# https://github.com/saltstack/salt/issues/39314') %}
 {%-           do prov_cmds.append('- zypper rm python-boto3 -y') %}
 {%-         endif %}
@@ -114,7 +114,7 @@ provision_command:
 
 {%- macro format_driver_run_cmds(os, os_ver) %}
 {%-   filter indent(6) %}
-{%-     if os in ['opensuse/leap', 'arch-base'] %}
+{%-     if os in ['opensuse/leap', 'opensuse/tmbl', 'arch-base'] %}
 run_command: /usr/lib/systemd/systemd
 {%-     elif [os, os_ver] in [['amazonlinux', 1], ['centos', 6], ['gentoo/stage3', 'latest']] %}
 run_command: /sbin/init
@@ -183,13 +183,11 @@ platforms:
       {{- format_driver_image(os, os_ver, salt_ver, py_ver, pre_salted) }}
       {{- format_driver_prov_cmds(os, os_ver, salt_ver, py_ver, pre_salted) }}
       {{- format_driver_run_cmds(os, os_ver) }}
-    {%- if os == 'opensuse/leap' %}
-    {%-   if os_ver in [15.1, 15.2] %}
-    # Workaround to avoid intermittent failures on `opensuse-leap-{{ os_ver }}`:
+    {%- if os.startswith('opensuse') %}
+    # Workaround to avoid intermittent failures on `opensuse-{{ 'tumbleweed' if os_ver == 'latest' else 'leap-' ~ os_ver }}`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-    {%-   endif %}
     {%- endif %}
 {%-   endif %}
 {%- endfor %}

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2859,11 +2859,7 @@ ssf:
           #       - '*':
           #           - ._mapdata
           #           - .
-          1:
-            includes: *includes_NONE
-            inspec_yml:
-              summary: >-
-                shared resources
+          1: *inspec_suites_kitchen__share_suite
           2:
             excludes: *platforms_os_amazonlinux_new
             inspec_yml:
@@ -2904,7 +2900,9 @@ ssf:
           - [amazonlinux  ,    2   ,   master,      3,     amazonlinux]
           # - [arch-base    ,  latest,   2019.2,      2,            repo]
         use_tofs: true
-      semrel_files: *semrel_files_default
+      semrel_files:
+        <<: *semrel_files_default
+        inspec/libraries/system.rb: *file__inspec__libraries__system--rb
     mattermost:
       context:
         codeowners:
@@ -4085,11 +4083,7 @@ ssf:
           #       - '*':
           #           - ._mapdata
           #           - .
-          1:
-            includes: *includes_NONE
-            inspec_yml:
-              summary: >-
-                shared resources
+          1: *inspec_suites_kitchen__share_suite
         platforms: *platforms_new_inc_tiamat
         # If `opensuse/leap` fixed, then can use this instead
         # platforms_matrix: *platforms_matrix_new_inc_tiamat
@@ -4111,7 +4105,9 @@ ssf:
           # # - [opensuse/leap,   15.2 ,   master,      3,         default]
           - [arch-base    ,  latest,   3000.3,      2,         default]
         use_tofs: true
-      semrel_files: *semrel_files_default
+      semrel_files:
+        <<: *semrel_files_default
+        inspec/libraries/system.rb: *file__inspec__libraries__system--rb
     rspamd:
       context:
         codeowners:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -136,6 +136,7 @@ ssf_node_anchors:
           # - [fedora       ,   33   ,   tiamat,      3]  # fedo-33.0-tiamat-py3
           # - [fedora       ,   32   ,   tiamat,      3]  # fedo-32.0-tiamat-py3
           # - [opensuse/leap,   15.2 ,   tiamat,      3]  # opsu-15.2-tiamat-py3
+          # - [opensuse/tmbl,  latest,   tiamat,      3]  # opsu-tmbl-tiamat-py3
           - [amazonlinux  ,    2   ,   tiamat,      3]  # amaz-02.0-tiamat-py3
           - [oraclelinux  ,    8   ,   tiamat,      3]  # orac-08.0-tiamat-py3
           - [oraclelinux  ,    7   ,   tiamat,      3]  # orac-07.0-tiamat-py3
@@ -151,6 +152,7 @@ ssf_node_anchors:
           - [fedora       ,   33   ,   master,      3]  # fedo-33.0-master-py3
           - [fedora       ,   32   ,   master,      3]  # fedo-32.0-master-py3
           - [opensuse/leap,   15.2 ,   master,      3]  # opsu-15.2-master-py3
+          - [opensuse/tmbl,  latest,   master,      3]  # opsu-tmbl-master-py3
           - [amazonlinux  ,    2   ,   master,      3]  # amaz-02.0-master-py3
           - [oraclelinux  ,    8   ,   master,      3]  # orac-08.0-master-py3
           # # Fails due to dependency issues, probably ignore permanently
@@ -169,6 +171,7 @@ ssf_node_anchors:
           - [fedora       ,   33   ,   3002.2,      3]  # fedo-33.0-3002.2-py3
           - [fedora       ,   32   ,   3002.2,      3]  # fedo-32.0-3002.2-py3
           - [opensuse/leap,   15.2 ,   3002.2,      3]  # opsu-15.2-3002.2-py3
+          - [opensuse/tmbl,  latest,   3002.2,      3]  # opsu-tmbl-3002.2-py3
           - [amazonlinux  ,    2   ,   3002.2,      3]  # amaz-02.0-3002.2-py3
           - [oraclelinux  ,    8   ,   3002.2,      3]  # orac-08.0-3002.2-py3
           - [oraclelinux  ,    7   ,   3002.2,      3]  # orac-07.0-3002.2-py3
@@ -187,6 +190,7 @@ ssf_node_anchors:
           - [fedora       ,   33   ,   3001.4,      3]  # fedo-33.0-3001.4-py3
           - [fedora       ,   32   ,   3001.4,      3]  # fedo-32.0-3001.4-py3
           - [opensuse/leap,   15.2 ,   3001.4,      3]  # opsu-15.2-3001.4-py3
+          - [opensuse/tmbl,  latest,   3001.4,      3]  # opsu-tmbl-3001.4-py3
           - [amazonlinux  ,    2   ,   3001.4,      3]  # amaz-02.0-3001.4-py3
           - [oraclelinux  ,    8   ,   3001.4,      3]  # orac-08.0-3001.4-py3
           - [oraclelinux  ,    7   ,   3001.4,      3]  # orac-07.0-3001.4-py3
@@ -317,15 +321,16 @@ ssf_node_anchors:
           # - [ubuntu       ,   16.04,   master,      3,         default]
           - [centos       ,    8   ,   master,      3,         default]
           # - [centos       ,    7   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          # - [fedora       ,   31   ,   master,      3,         default]
+          - [fedora       ,   33   ,   master,      3,         default]
+          # - [fedora       ,   32   ,   master,      3,         default]
           - [opensuse/leap,   15.2 ,   master,      3,         default]
+          - [opensuse/tmbl,  latest,   master,      3,         default]
           - [amazonlinux  ,    2   ,   master,      3,         default]
           # # - [oraclelinux  ,    8   ,   master,      3,         default]
           # # - [oraclelinux  ,    7   ,   master,      3,         default]
           # # - [gentoo/stage3,  latest,   master,      3,         default]
           # # - [gentoo/stage3, systemd,   master,      3,         default]
-          - [arch-base    ,  latest,   3000.3,      2,         default]
+          - [arch-base    ,  latest,   3000.6,      2,         default]
 
         # Use this to start adopting the latest `platforms_matrix` (after Tiamat)
         # based on `tiamat` & `master` images primarily
@@ -3436,6 +3441,7 @@ ssf:
           # # - [fedora       ,   33   ,   master,      3,         default]
           # # - [fedora       ,   32   ,   master,      3,         default]
           - [opensuse/leap,   15.2 ,   master,      3,         default]
+          - [opensuse/tmbl,  latest,   master,      3,         default]
           - [amazonlinux  ,    2   ,   master,      3,         default]
           # # - [oraclelinux  ,    8   ,   master,      3,         default]
           # # - [gentoo/stage3,  latest,   master,      3,         default]
@@ -4177,6 +4183,7 @@ ssf:
               - [fedora       ,   33   ,   3002.2,      3]
               - [fedora       ,   32   ,   3002.2,      3]
               - [opensuse/leap,   15.2 ,   3002.2,      3]
+              - [opensuse/tmbl,  latest,   3002.2,      3]
               - [amazonlinux  ,    2   ,   3002.2,      3]
               - [oraclelinux  ,    8   ,   3002.2,      3]
               - [oraclelinux  ,    7   ,   3002.2,      3]
@@ -4210,6 +4217,7 @@ ssf:
               - [fedora       ,   33   ,   3001.4,      3]
               - [fedora       ,   32   ,   3001.4,      3]
               - [opensuse/leap,   15.2 ,   3001.4,      3]
+              - [opensuse/tmbl,  latest,   3001.4,      3]
               - [amazonlinux  ,    2   ,   3001.4,      3]
               - [oraclelinux  ,    8   ,   3001.4,      3]
               - [oraclelinux  ,    7   ,   3001.4,      3]
@@ -4300,8 +4308,8 @@ ssf:
           - [fedora       ,   33   ,   3002.2,      3,       v3002-py3]
           # # Still installs `3001.4-1.fc32`
           # # - [fedora       ,   32   ,   3002.2,      3,       v3002-py3]
-          # # Still installs `3000.3-lp152.4.1`
-          # # - [opensuse/leap,   15.2 ,   3002.2,      3,       v3002-py3]
+          - [opensuse/leap,   15.2 ,   3002.2,      3,       v3002-py3]
+          - [opensuse/tmbl,  latest,   3002.2,      3,       v3002-py3]
           - [amazonlinux  ,    2   ,   3002.2,      3,       v3002-py3]
           - [oraclelinux  ,    8   ,   3002.2,      3,       v3002-py3]
           - [oraclelinux  ,    7   ,   3002.2,      3,       v3002-py3]
@@ -4318,8 +4326,9 @@ ssf:
           # # Probably doesn't work with Python 3.9
           # # - [fedora       ,   33   ,   3001.4,      3,       v3001-py3]
           - [fedora       ,   32   ,   3001.4,      3,       v3001-py3]
-          # # Still installs `3000.3-lp152.4.1`
+          # # Installs `3002.2`
           # # - [opensuse/leap,   15.2 ,   3001.4,      3,       v3001-py3]
+          # # - [opensuse/tmbl,  latest,   3001.4,      3,       v3001-py3]
           # - [amazonlinux  ,    2   ,   3001.4,      3,       v3001-py3]
           - [oraclelinux  ,    8   ,   3001.4,      3,       v3001-py3]
           # - [oraclelinux  ,    7   ,   3001.4,      3,       v3001-py3]
@@ -4332,7 +4341,8 @@ ssf:
           # - [ubuntu       ,   16.04,   3000.6,      3,       v3000-py3]
           # - [centos       ,    8   ,   3000.6,      3,       v3000-py3]
           - [centos       ,    7   ,   3000.6,      3,       v3000-py3]
-          - [opensuse/leap,   15.2 ,   3000.6,      3,       v3000-py3]
+          # # Installs `3002.2`
+          # # - [opensuse/leap,   15.2 ,   3000.6,      3,       v3000-py3]
           # - [amazonlinux  ,    2   ,   3000.6,      3,       v3000-py3]
           # - [oraclelinux  ,    8   ,   3000.6,      3,       v3000-py3]
           - [oraclelinux  ,    7   ,   3000.6,      3,       v3000-py3]


### PR DESCRIPTION
* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/78

Regarding changes to `kitchen.yml`, confirmed that the
`max_ssh_sessions` was also needed for `opensuse/tumbleweed`:

* https://gitlab.com/myii/openvpn-formula/-/jobs/983088326#L421

---

Only a couple of formulas are using `*platforms_new_saltimages` so have the actual platforms update.  The rest of the formulas are having the latest version of the `share` InSpec suite pushed to them.