### PR TITLE
feat: overhaul CI implementation and use latest pre-salted images

### DIFF
--- a/ssf/config/formulas.sls
+++ b/ssf/config/formulas.sls
@@ -58,7 +58,7 @@ prepare-git-branch-for-{{ formula }}:
 {#-     Work through each inspec suite defined for the formula, ordered by the suite number #}
 {%-     for index in range(0, inspec_suites_kitchen | length) %}
 {%-       set suite = inspec_suites_kitchen[index] %}
-{%-       set dest_file = semrel_file_specs.dest_file | d(semrel_file ) %}
+{%-       set dest_file = semrel_file_specs.dest_file | d(semrel_file) %}
 {#-       Only manage files for the suite if the `suite.name` is set #}
 {#-       Or if dealing with CI files (where an empty `suite.name` is actually used) #}
 {%-       if suite.name or dest_file in ['.cirrus.yml', '.travis.yml'] %}

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -753,20 +753,23 @@ ssf:
             name: 'adopt'
           1:
             <<: *isk_suite_default
-            name: 'amazon'
+            name: 'share'
           2:
             <<: *isk_suite_default
-            name: 'graalvm'
+            name: 'amazon'
           3:
             <<: *isk_suite_default
-            name: 'haikuvm'
+            name: 'graalvm'
           4:
             <<: *isk_suite_default
-            name: 'intellij'
+            name: 'haikuvm'
           5:
             <<: *isk_suite_default
-            name: 'oracle'
+            name: 'intellij'
           6:
+            <<: *isk_suite_default
+            name: 'oracle'
+          7:
             <<: *isk_suite_default
             name: 'zulu'
     jetbrains-appcode: *formula_default

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -880,7 +880,6 @@ ssf:
           3:
             <<: *isk_suite_default
             name: ''
-    mattermost: *formula_default
     maven:
       <<: *formula_default
       context:
@@ -1114,7 +1113,6 @@ ssf:
     sqldeveloper: *formula_default
     sqlplus: *formula_default
     ssf: *formula_default
-    stack: *formula_default
     strongswan: *formula_default
     stunnel: *formula_default
     sudoers:

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -62,8 +62,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(yamllint): add '`'.git/'`' to ignores [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/297'
+            title: "ci(kitchen+gitlab-ci): use latest pre-salted images"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/293'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'
@@ -109,7 +109,10 @@ ssf_node_anchors:
                 - suse
                 - freebsd
                 - amazon
+                - oracle
                 - arch
+                - gentoo
+                - windows
             provisioner:
               dependencies: []
               # Structure assumes `top.sls:base`
@@ -135,69 +138,20 @@ ssf_node_anchors:
           filename: 'map.jinja'
           verification: {}
         platforms:
-          # Could use `opensuse-leap` throughout since `/` never used at this end
-          # Would have to modify the `if` in the `kitchen.yml` template(s), though
-          # Also, may have to be careful with versions such as `18.04` being seen
-          # as numbers (for comparisons)
           # [os           ,  os_ver, salt_ver, py_ver]
-
-          ### `master-py3`
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [centos       ,    8   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [opensuse/leap,   15.1 ,   master,      3]
-          ### ` master-py2`
-          - [amazonlinux  ,    2   ,   master,      3]
-
-          ### `2019.2-py3`
-          - [debian       ,   10   ,   2019.2,      3]
-          - [debian       ,    9   ,   2019.2,      3]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          # - [ubuntu       ,   16.04,   2019.2,      3]
-          - [centos       ,    8   ,   2019.2,      3]
-          # - [centos       ,    7   ,   2019.2,      3]
-          - [fedora       ,   31   ,   2019.2,      3]
-          - [opensuse/leap,   15.1 ,   2019.2,      3]
-          ### `2019.2-py2`
-          # - [ubuntu       ,   18.04,   2019.2,      2]
-          - [centos       ,    7   ,   2019.2,      2]
-          - [amazonlinux  ,    2   ,   2019.2,      3]
-          - [arch-base    ,  latest,   2019.2,      2]
-
-          ### `2018.3-py3`
-          - [fedora       ,   30   ,   2018.3,      3]
-          ### `2018.3-py2`
-          # - [debian       ,   10   ,   2018.3,      2]
-          - [debian       ,    9   ,   2018.3,      2]
-          # - [debian       ,    8   ,   2018.3,      2]
-          # - [ubuntu       ,   18.04,   2018.3,      2]
-          - [ubuntu       ,   16.04,   2018.3,      2]
-          - [centos       ,    7   ,   2018.3,      2]
-          # - [centos       ,    6   ,   2018.3,      2]
-          - [opensuse/leap,   15.1 ,   2018.3,      2]
-          - [amazonlinux  ,    1   ,   2018.3,      2]
-          - [arch-base    ,  latest,   2018.3,      2]
-
-          ### `2017.7-py2`
-          - [debian       ,    8   ,   2017.7,      2]
-          - [ubuntu       ,   16.04,   2017.7,      2]
-          - [centos       ,    6   ,   2017.7,      2]
-          - [fedora       ,   30   ,   2017.7,      2]
-          - [opensuse/leap,   15.1 ,   2017.7,      2]
-          - [amazonlinux  ,    1   ,   2017.7,      2]
-          - [arch-base    ,  latest,   2017.7,      2]
-
+          - [0            ,    0   ,      0  ,      0]
         platforms_matrix:
-          # Comments in `platforms` apply here, too
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [opensuse/leap,   15.1 ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          - [arch-base    ,  latest,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         # To deal with excessive instances when mimicking `kitchen list -b`
         # If values are set, only use these as commented entries in the matrix
         platforms_matrix_commented_includes: []
@@ -346,8 +300,7 @@ ssf:
     - [opensuse/tmbl,  latest,   master,      3]  # opsu-tmbl-master-py3
     - [amazonlinux  ,    2   ,   master,      3]  # amaz-02.0-master-py3
     - [oraclelinux  ,    8   ,   master,      3]  # orac-08.0-master-py3
-    # # Fails due to dependency issues, probably ignore permanently
-    # - [oraclelinux  ,    7   ,   master,      3]  # orac-07.0-master-py3
+    - [oraclelinux  ,    7   ,   master,      3]  # orac-07.0-master-py3
     - [gentoo/stage3,  latest,   master,      3]  # gent-late-master-py3
     - [gentoo/stage3, systemd,   master,      3]  # gent-sysd-master-py3
 
@@ -407,6 +360,7 @@ ssf:
     - [ubuntu       ,   16.04,   3000.6,      2]  # ubun-16.0-3000.6-py2
     - [arch-base    ,  latest,   3000.6,      2]  # arch-late-3000.6-py2
 
+  saltimages_deprecated:
     ### Deprecated, no longer being built but still available in Docker Hub
     ### `master-py3`
     - [fedora       ,   31   ,   master,      3]  # fedo-31.0-master-py3
@@ -580,7 +534,7 @@ ssf:
             name: 'modules'
           2:
             <<: *isk_suite_default
-            name: 'arch'
+            name: ''
     apt:
       <<: *formula_default
       context:
@@ -716,6 +670,9 @@ ssf:
           1:
             <<: *isk_suite_default
             name: 'package'
+          2:
+            <<: *isk_suite_default
+            name: ''
     grafana: *formula_default
     haproxy: *formula_default
     hostsfile: *formula_default
@@ -730,6 +687,9 @@ ssf:
           1:
             <<: *isk_suite_default
             name: 'tables'
+          2:
+            <<: *isk_suite_default
+            name: ''
     iscsi:
       <<: *formula_default
       context:
@@ -919,7 +879,7 @@ ssf:
             name: 'repo'
           3:
             <<: *isk_suite_default
-            name: 'amazonlinux'
+            name: ''
     mattermost: *formula_default
     maven:
       <<: *formula_default
@@ -960,6 +920,9 @@ ssf:
           1:
             <<: *isk_suite_default
             name: 'mode-eq-none'
+          2:
+            <<: *isk_suite_default
+            name: ''
     openldap: *formula_default
     openntpd:
       <<: *formula_default
@@ -1021,6 +984,9 @@ ssf:
           9:
             <<: *isk_suite_default
             name: 'arch'
+          10:
+            <<: *isk_suite_default
+            name: 'gentoo'
     php:
       <<: *formula_default
       context:
@@ -1059,18 +1025,21 @@ ssf:
         <<: *context_default
         inspec_suites_kitchen:
           <<: *isk_default
-          0:
-            <<: *isk_suite_default
-            name: 'debian'
           1:
             <<: *isk_suite_default
-            name: 'redhat'
+            name: 'debian'
           2:
             <<: *isk_suite_default
-            name: 'suse'
+            name: 'redhat'
           3:
             <<: *isk_suite_default
+            name: 'suse'
+          4:
+            <<: *isk_suite_default
             name: 'amazonlinux'
+          5:
+            <<: *isk_suite_default
+            name: 'gentoo'
     prometheus:
       <<: *formula_default
       context:
@@ -1080,6 +1049,9 @@ ssf:
           1:
             <<: *isk_suite_default
             name: 'repo'
+          2:
+            <<: *isk_suite_default
+            name: ''
     rabbitmq:
       <<: *formula_default
       context:
@@ -1170,9 +1142,6 @@ ssf:
             <<: *isk_suite_default
             name: 'share'
           2:
-            <<: *isk_suite_default
-            name: 'upstart'
-          3:
             <<: *isk_suite_default
             name: 'gentoo'
     timezone: *formula_default

--- a/ssf/files/default/.gitlab-ci.yml
+++ b/ssf/files/default/.gitlab-ci.yml
@@ -131,6 +131,7 @@ rubocop:
   before_script:
     {%- if semrel_formula == 'keepalived' %}
     - 'apk --no-cache add ipvsadm'
+    - 'modprobe ip_vs || true'
     {%- endif %}
     # TODO: This should work from the env vars above automatically
     - 'bundle config set path "${BUNDLE_CACHE_PATH}"'

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -26,11 +26,29 @@
 {%-     if cludes %}
 {{ clude_type }}:
 {#-       Centralise duplication from here and `libcimatrix.jinja` #}
-{%-       for platform in cludes %}
+{%-       for platform in saltimages %}
 {%-         set os       = platform[0] | d('') %}
 {%-         set os_ver   = platform[1] | d('') %}
 {%-         set salt_ver = platform[2] | d('') %}
 {%-         set py_ver   = platform[3] | d('') %}
+
+{#-         Check if the platform matches any of the `platforms` listed #}
+{%-         set ns_check_platform = namespace(match=False) %}
+{%-         for check in cludes %}
+{%-           set ch_os       = check[0] if check[0] else platform[0] %}
+{%-           set ch_os_ver   = check[1] if check[1] else platform[1] %}
+{%-           set ch_salt_ver = check[2] if check[2] else platform[2] %}
+{%-           set ch_py_ver   = check[3] if check[3] else platform[3] %}
+{%-           if platform == [ch_os, ch_os_ver, ch_salt_ver, ch_py_ver] %}
+{%-             set ns_check_platform.match = True %}
+{%-             break %}
+{%-           endif %}
+{%-         endfor %}
+{#-         If a match hasn't been found, go to the next entry under `saltimages` #}
+{%-         if not ns_check_platform.match %}
+{%-           continue %}
+{%-         endif %}
+
 {#-         Concatenate the `INSTANCE` or set to `NONE` otherwise #}
 {%-         if not platform %}
 {%-           set instance = 'NONE' %}
@@ -92,14 +110,22 @@ image: {{ 'saltimages' if [os, os_ver, salt_ver, py_ver] in saltimages else 'net
 {#-     General for all Salt versions #}
 {%-     if semrel_formula == 'packages' %}
 {%-       if [os, os_ver] in [['debian', 10], ['debian', 9]] %}
+{%-         do prov_cmds.append('- apt-get update') %}
 {%-         do prov_cmds.append('- apt-get install --reinstall -y udev') %}
 {%-         do prov_cmds.append('- apt-get install -y snapd') %}
 {%-       endif %}
 {%-     elif semrel_formula == 'systemd' %}
 {%-       if os in ['fedora'] %}
+{%-         do prov_cmds.append('- dnf -y update') %}
 {%-         do prov_cmds.append('- dnf -y reinstall udev') %}
 {%-       elif os in ['arch-base'] %}
 {%-         do prov_cmds.append('- pacman --noconfirm -Syu systemd') %}
+{%-       endif %}
+{%-     elif semrel_formula == 'libvirt' %}
+{%-       if [os, os_ver] in [['fedora', 33]] %}
+{%-         do prov_cmds.append('- dnf -y update') %}
+{%-         do prov_cmds.append('- dnf install -y crypto-policies-scripts') %}
+{%-         do prov_cmds.append('- update-crypto-policies --set LEGACY') %}
 {%-       endif %}
 {%-     endif %}
 {#-     Prepare the commands if available#}
@@ -146,16 +172,35 @@ driver:
     {%- endfor %}
   {%- endif %}
 
-# Make sure the platforms listed below match up with
-# the `env.matrix` instances defined in `.travis.yml`
 platforms:
 {#- Centralise duplication from here and `libcimatrix.jinja` #}
 {%- set ns_platforms = namespace(prev_comment='') %}
-{%- for platform in platforms %}
+
+{#- Work through all `saltimages` for ordering purposes; #}
+{#- Only matching elements will be used (covered by the subsequent `for` loop #}
+{%- for platform in saltimages %}
 {%-   set os       = platform[0] %}
 {%-   set os_ver   = platform[1] %}
 {%-   set salt_ver = platform[2] %}
 {%-   set py_ver   = platform[3] %}
+
+{#-   Check if the platform matches any of the `platforms` listed #}
+{%-   set ns_check_platform = namespace(match=False) %}
+{%-   for check in platforms %}
+{%-     set ch_os       = check[0] if check[0] else platform[0] %}
+{%-     set ch_os_ver   = check[1] if check[1] else platform[1] %}
+{%-     set ch_salt_ver = check[2] if check[2] else platform[2] %}
+{%-     set ch_py_ver   = check[3] if check[3] else platform[3] %}
+{%-     if platform == [ch_os, ch_os_ver, ch_salt_ver, ch_py_ver] %}
+{%-       set ns_check_platform.match = True %}
+{%-       break %}
+{%-     endif %}
+{%-   endfor %}
+{#-   If a match hasn't been found, go to the next entry under `saltimages` #}
+{%-   if not ns_check_platform.match %}
+{%-     continue %}
+{%-   endif %}
+
 {#-   Was used for `[['amazonlinux', 1]]` but now leaving blank in case it's needed in the future #}
 {%-   set pre_salted = [os, os_ver] not in [[]] %}
 {#-   Display comment for each section (based on Salt version) #}
@@ -227,6 +272,20 @@ suites:
       {%-   endfor %}
     {%-   endif %}
     provisioner:
+      {#- dependencies #}
+      {#- Centralise duplication from here and `inspec.yml` #}
+      {%- set dependencies = suite.provisioner.dependencies %}
+      {%- if dependencies %}
+      dependencies:
+        {%- for dependency in dependencies %}
+        - name: {{ dependency.name }}
+        {%-   for k, v in dependency.items() %}
+        {%-     if k != 'name' %}
+          {{ k }}: {{ v }}
+        {%-     endif %}
+        {%-   endfor %}
+        {%- endfor %}
+      {%- endif %}
       state_top:
         base:
           {{- format_matcher(suite.provisioner.state_top) }}
@@ -244,20 +303,6 @@ suites:
         {%-       set k = semrel_formula ~ k %}
         {%-     endif %}
         {{ k }}: {{ v }}
-        {%-   endfor %}
-        {%- endfor %}
-      {%- endif %}
-      {#- dependencies #}
-      {#- Centralise duplication from here and `inspec.yml` #}
-      {%- set dependencies = suite.provisioner.dependencies %}
-      {%- if dependencies %}
-      dependencies:
-        {%- for dependency in dependencies %}
-        - name: {{ dependency.name }}
-        {%-   for k, v in dependency.items() %}
-        {%-     if k != 'name' %}
-          {{ k }}: {{ v }}
-        {%-     endif %}
         {%-   endfor %}
         {%- endfor %}
       {%- endif %}

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3437,7 +3437,7 @@ ssf:
           1: *inspec_suites_kitchen__share_suite
         map_jinja:
           verification:
-            import: ['map']
+            import: ['mapdata']
         platforms: *platforms_new_saltimages
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
@@ -3458,6 +3458,7 @@ ssf:
           # # - [gentoo/stage3, systemd,   master,      3,         default]
           - [oraclelinux  ,    7   ,   3002.2,      3,         default]
           # # - [arch-base    ,  latest,   3002.2,      3,         default]
+        use_libsaltcli: true
         yamllint:
           ignore:
             additional:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -108,6 +108,10 @@ ssf_node_anchors:
                     - .pkgrepo
                     - .master
                     - .minion
+              state_top_inc_mapdata: &state_top_inc_mapdata
+                - '*':
+                    - ._mapdata
+                    - .
             verifier: &verifier_inspec_tests_default
               inspec_tests:
                 - default
@@ -1540,10 +1544,7 @@ ssf:
               summary: >-
                 Verify that the firewalld formula is setup and configured correctly
             provisioner:
-              state_top:
-                - '*':
-                    - ._mapdata
-                    - .
+              state_top: *state_top_inc_mapdata
           1: *inspec_suites_kitchen__share_suite
         map_jinja:
           verification:
@@ -1888,33 +1889,55 @@ ssf:
             repo: 'java-formula'
         inspec_suites_kitchen:
           0:
+            inspec_yml:
+              depends: *depends_on_suite_share
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/adopt/pillar.sls'
-          1:
+              state_top: *state_top_inc_mapdata
+          1: *inspec_suites_kitchen__share_suite
+          2:
+            inspec_yml:
+              depends: *depends_on_suite_share
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/amazon/pillar.sls'
-          2:
+              state_top: *state_top_inc_mapdata
+          3:
+            inspec_yml:
+              depends: *depends_on_suite_share
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/graalvm/pillar.sls'
-          3:
+              state_top: *state_top_inc_mapdata
+          4:
+            inspec_yml:
+              depends: *depends_on_suite_share
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/haikuvm/pillar.sls'
-          4:
+              state_top: *state_top_inc_mapdata
+          5:
+            inspec_yml:
+              depends: *depends_on_suite_share
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/intellij/pillar.sls'
-          5:
+              state_top: *state_top_inc_mapdata
+          6:
+            inspec_yml:
+              depends: *depends_on_suite_share
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/oracle/pillar.sls'
-          6:
+              state_top: *state_top_inc_mapdata
+          7:
+            inspec_yml:
+              depends: *depends_on_suite_share
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/zulu/pillar.sls'
+              state_top: *state_top_inc_mapdata
         inspec_suites_matrix:
           - adopt
           - amazon
@@ -1923,7 +1946,9 @@ ssf:
           - intellij
           - oracle
           - zulu
-        platforms: *platforms_new
+        map_jinja:
+          verification:
+            import: ['java']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [ubuntu       ,   18.04,   master,      3,           adopt]
@@ -1951,7 +1976,7 @@ ssf:
             additional:
               - pillar.example
               - java/osfamilymap.yaml
-      semrel_files: *semrel_files_default
+      semrel_files: *semrel_files_inc_map_jinja_verifier
     jetbrains-appcode:
       context:
         codeowners:
@@ -3358,10 +3383,7 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/openntpd.sls'
-              state_top:
-                - '*':
-                    - ._mapdata
-                    - .
+              state_top: *state_top_inc_mapdata
           1: *inspec_suites_kitchen__share_suite
         map_jinja:
           verification:
@@ -3707,10 +3729,7 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/redhat.sls'
-              state_top:
-                - '*':
-                    - ._mapdata
-                    - .
+              state_top: *state_top_inc_mapdata
             verifier: *verifier_inspec_tests_default
           5:
             includes: *platforms_osfamily_suse

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2687,35 +2687,6 @@ ssf:
       semrel_files:
         <<: *semrel_files_default
         inspec/libraries/system.rb: *file__inspec__libraries__system--rb
-    mattermost:
-      context:
-        codeowners:
-          entries:
-            global:
-              - '*': '@kjkeane'
-        git:
-          github:
-            owner: 'kjkeane'
-            repo: 'mattermost-formula'
-        inspec_suites_kitchen:
-          0:
-            inspec_yml:
-              summary: >-
-                Verify that the mattermost formula is setup and configured correctly
-            provisioner:
-              pillars_from_files:
-                - .sls: 'test/salt/default/pillar/mattermost.sls'
-        # Based on `platforms_matrix_systemd_only`,
-        # simply because `centos-6` not working
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          - [arch-base    ,  latest,   2018.3,      2,         default]
-      semrel_files: *semrel_files_default
     maven:
       context:
         codeowners:
@@ -4228,41 +4199,6 @@ ssf:
         pre-commit_semantic-release.sh: *file__pre-commit_semantic-release--sh
         release-rules.js: *file__release-rules--js
         release.config.js: *file__release--config--js
-    stack:
-      context:
-        codeowners:
-          entries:
-            global:
-              - '*': '@claudekenni'
-        git:
-          github:
-            owner: 'claudekenni'
-            repo: 'stack-formula'
-        inspec_suites_kitchen:
-          0:
-            inspec_yml:
-              summary: >-
-                Verify that the stack formula is setup and configured correctly
-              supports:
-                - debian
-                - ubuntu
-                - centos
-        travis: *travis_do_not_use_single_job_for_linters
-        use_tofs: true
-      semrel_files:
-        .github/workflows/commitlint.yml: *file__--github__workflows__commitlint--yml
-        docs/TOFS_pattern.rst:
-          <<: *file__docs__TOFS_pattern--rst
-          dest_file: 'TOFS_pattern.rst'
-        formula/libtofs.jinja:
-          <<: *file__formula__libtofs--jinja
-          dest_file: 'formula/macros.jinja'
-        inspec/inspec.yml: *file__inspec__inspec--yml
-        inspec/README.md: *file__inspec__README--md
-        .gitignore: *file__--gitignore
-        CODEOWNERS: *file__CODEOWNERS
-        Gemfile: *file__Gemfile
-        Gemfile.lock: *file__Gemfile--lock
     strongswan:
       context:
         codeowners:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1948,34 +1948,22 @@ ssf:
           - zulu
         map_jinja:
           verification:
-            import: ['java']
+            import: ['mapdata']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [ubuntu       ,   18.04,   master,      3,           adopt]
-          - [ubuntu       ,   18.04,   master,      3,          amazon]
-          - [ubuntu       ,   18.04,   master,      3,         graalvm]
-          - [ubuntu       ,   18.04,   master,      3,         haikuvm]
-          - [ubuntu       ,   18.04,   master,      3,        intellij]
-          # - [ubuntu       ,   18.04,   master,      3,          oracle]
-          - [ubuntu       ,   18.04,   master,      3,            zulu]
-        # To deal with excessive instances when mimicking `kitchen list -b`
-        # If values are set, only use these as commented entries in the matrix
-        platforms_matrix_commented_includes:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,           adopt]
-          - [ubuntu       ,   20.04,   master,      3,           adopt]
-          - [ubuntu       ,   18.04,   master,      3,           adopt]
-          - [centos       ,    8   ,   master,      3,           adopt]
-          - [fedora       ,   32   ,   master,      3,           adopt]
-          - [fedora       ,   31   ,   master,      3,           adopt]
-          - [opensuse/leap,   15.2 ,   master,      3,           adopt]
-          - [amazonlinux  ,    2   ,   master,      3,           adopt]
+          - [ubuntu       ,    0   ,   master,      0,           adopt]
+          - [ubuntu       ,    0   ,   master,      0,          amazon]
+          - [ubuntu       ,    0   ,   master,      0,         graalvm]
+          - [ubuntu       ,    0   ,   master,      0,         haikuvm]
+          - [ubuntu       ,    0   ,   master,      0,        intellij]
+          # # - [ubuntu       ,    0   ,   master,      0,          oracle]
+          - [ubuntu       ,    0   ,   master,      0,            zulu]
+        use_libsaltcli: true
         use_tofs: true
         yamllint:
           ignore:
             additional:
               - pillar.example
-              - java/osfamilymap.yaml
       semrel_files: *semrel_files_inc_map_jinja_verifier
     jetbrains-appcode:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -5037,6 +5037,9 @@ ssf:
         formula/_mapdata/init.sls:
           <<: *file__formula___mapdata___init--sls
           alt_semrel_formula: 'TEMPLATE'
+        inspec/controls/_mapdata.rb:
+          <<: *file__inspec__controls___mapdata--rb
+          alt_semrel_formula: 'TEMPLATE'
     timezone:
       context:
         git:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -39,6 +39,16 @@ ssf_node_anchors:
                 - centos
                 - fedora
                 - amazon
+              supports_centos_amazon_oracle: &supports_centos_amazon_oracle
+                - centos
+                - amazon
+                - oracle
+              # yamllint disable-line rule:line-length
+              supports_centos_fedora_amazon_oracle: &supports_centos_fedora_amazon_oracle
+                - centos
+                - fedora
+                - amazon
+                - oracle
               supports_all_except_amazon: &supports_all_except_amazon
                 - debian
                 - ubuntu
@@ -128,191 +138,18 @@ ssf_node_anchors:
         # However, `master` images will be used in place of `tiamat`, until they
         # become viable.
         platforms_new_saltimages: &platforms_new_saltimages
-          ### `tiamat-py3`
-          - [debian       ,   10   ,   tiamat,      3]  # debi-10.0-tiamat-py3
-          - [debian       ,    9   ,   tiamat,      3]  # debi-09.0-tiamat-py3
-          - [ubuntu       ,   20.04,   tiamat,      3]  # ubun-20.0-tiamat-py3
-          - [ubuntu       ,   18.04,   tiamat,      3]  # ubun-18.0-tiamat-py3
-          - [ubuntu       ,   16.04,   tiamat,      3]  # ubun-16.0-tiamat-py3
-          - [centos       ,    8   ,   tiamat,      3]  # cent-08.0-tiamat-py3
-          - [centos       ,    7   ,   tiamat,      3]  # cent-07.0-tiamat-py3
-          # # Not available at the current time
-          # - [fedora       ,   33   ,   tiamat,      3]  # fedo-33.0-tiamat-py3
-          # - [fedora       ,   32   ,   tiamat,      3]  # fedo-32.0-tiamat-py3
-          # - [opensuse/leap,   15.2 ,   tiamat,      3]  # opsu-15.2-tiamat-py3
-          # - [opensuse/tmbl,  latest,   tiamat,      3]  # opsu-tmbl-tiamat-py3
-          - [amazonlinux  ,    2   ,   tiamat,      3]  # amaz-02.0-tiamat-py3
-          - [oraclelinux  ,    8   ,   tiamat,      3]  # orac-08.0-tiamat-py3
-          - [oraclelinux  ,    7   ,   tiamat,      3]  # orac-07.0-tiamat-py3
-
-          ### `master-py3`
-          - [debian       ,   10   ,   master,      3]  # debi-10.0-master-py3
-          - [debian       ,    9   ,   master,      3]  # debi-09.0-master-py3
-          - [ubuntu       ,   20.04,   master,      3]  # ubun-20.0-master-py3
-          - [ubuntu       ,   18.04,   master,      3]  # ubun-18.0-master-py3
-          - [ubuntu       ,   16.04,   master,      3]  # ubun-16.0-master-py3
-          - [centos       ,    8   ,   master,      3]  # cent-08.0-master-py3
-          - [centos       ,    7   ,   master,      3]  # cent-07.0-master-py3
-          - [fedora       ,   33   ,   master,      3]  # fedo-33.0-master-py3
-          - [fedora       ,   32   ,   master,      3]  # fedo-32.0-master-py3
-          - [opensuse/leap,   15.2 ,   master,      3]  # opsu-15.2-master-py3
-          - [opensuse/tmbl,  latest,   master,      3]  # opsu-tmbl-master-py3
-          - [amazonlinux  ,    2   ,   master,      3]  # amaz-02.0-master-py3
-          - [oraclelinux  ,    8   ,   master,      3]  # orac-08.0-master-py3
-          # # Fails due to dependency issues, probably ignore permanently
-          # - [oraclelinux  ,    7   ,   master,      3]  # orac-07.0-master-py3
-          - [gentoo/stage3,  latest,   master,      3]  # gent-late-master-py3
-          - [gentoo/stage3, systemd,   master,      3]  # gent-sysd-master-py3
-
-          ### `3002.2-py3`
-          - [debian       ,   10   ,   3002.2,      3]  # debi-10.0-3002.2-py3
-          - [debian       ,    9   ,   3002.2,      3]  # debi-09.0-3002.2-py3
-          - [ubuntu       ,   20.04,   3002.2,      3]  # ubun-20.0-3002.2-py3
-          - [ubuntu       ,   18.04,   3002.2,      3]  # ubun-18.0-3002.2-py3
-          - [ubuntu       ,   16.04,   3002.2,      3]  # ubun-16.0-3002.2-py3
-          - [centos       ,    8   ,   3002.2,      3]  # cent-08.0-3002.2-py3
-          - [centos       ,    7   ,   3002.2,      3]  # cent-07.0-3002.2-py3
-          - [fedora       ,   33   ,   3002.2,      3]  # fedo-33.0-3002.2-py3
-          - [fedora       ,   32   ,   3002.2,      3]  # fedo-32.0-3002.2-py3
-          - [opensuse/leap,   15.2 ,   3002.2,      3]  # opsu-15.2-3002.2-py3
-          - [opensuse/tmbl,  latest,   3002.2,      3]  # opsu-tmbl-3002.2-py3
-          - [amazonlinux  ,    2   ,   3002.2,      3]  # amaz-02.0-3002.2-py3
-          - [oraclelinux  ,    8   ,   3002.2,      3]  # orac-08.0-3002.2-py3
-          - [oraclelinux  ,    7   ,   3002.2,      3]  # orac-07.0-3002.2-py3
-          - [arch-base    ,  latest,   3002.2,      3]  # arch-late-3002.2-py3
-          - [gentoo/stage3,  latest,   3002.2,      3]  # gent-late-3002.2-py3
-          - [gentoo/stage3, systemd,   3002.2,      3]  # gent-sysd-3002.2-py3
-
-          ### `3001.4-py3`
-          - [debian       ,   10   ,   3001.4,      3]  # debi-10.0-3001.4-py3
-          - [debian       ,    9   ,   3001.4,      3]  # debi-09.0-3001.4-py3
-          - [ubuntu       ,   20.04,   3001.4,      3]  # ubun-20.0-3001.4-py3
-          - [ubuntu       ,   18.04,   3001.4,      3]  # ubun-18.0-3001.4-py3
-          - [ubuntu       ,   16.04,   3001.4,      3]  # ubun-16.0-3001.4-py3
-          - [centos       ,    8   ,   3001.4,      3]  # cent-08.0-3001.4-py3
-          - [centos       ,    7   ,   3001.4,      3]  # cent-07.0-3001.4-py3
-          - [fedora       ,   33   ,   3001.4,      3]  # fedo-33.0-3001.4-py3
-          - [fedora       ,   32   ,   3001.4,      3]  # fedo-32.0-3001.4-py3
-          - [opensuse/leap,   15.2 ,   3001.4,      3]  # opsu-15.2-3001.4-py3
-          - [opensuse/tmbl,  latest,   3001.4,      3]  # opsu-tmbl-3001.4-py3
-          - [amazonlinux  ,    2   ,   3001.4,      3]  # amaz-02.0-3001.4-py3
-          - [oraclelinux  ,    8   ,   3001.4,      3]  # orac-08.0-3001.4-py3
-          - [oraclelinux  ,    7   ,   3001.4,      3]  # orac-07.0-3001.4-py3
-          - [arch-base    ,  latest,   3001.4,      3]  # arch-late-3001.4-py3
-          - [gentoo/stage3,  latest,   3001.4,      3]  # gent-late-3001.4-py3
-          - [gentoo/stage3, systemd,   3001.4,      3]  # gent-sysd-3001.4-py3
-
-          ### `3000.6-py3`
-          - [debian       ,   10   ,   3000.6,      3]  # debi-10.0-3000.6-py3
-          - [debian       ,    9   ,   3000.6,      3]  # debi-09.0-3000.6-py3
-          - [ubuntu       ,   18.04,   3000.6,      3]  # ubun-18.0-3000.6-py3
-          - [ubuntu       ,   16.04,   3000.6,      3]  # ubun-16.0-3000.6-py3
-          - [centos       ,    8   ,   3000.6,      3]  # cent-08.0-3000.6-py3
-          - [centos       ,    7   ,   3000.6,      3]  # cent-07.0-3000.6-py3
-          - [opensuse/leap,   15.2 ,   3000.6,      3]  # opsu-15.2-3000.6-py3
-          - [amazonlinux  ,    2   ,   3000.6,      3]  # amaz-02.0-3000.6-py3
-          - [oraclelinux  ,    8   ,   3000.6,      3]  # orac-08.0-3000.6-py3
-          - [oraclelinux  ,    7   ,   3000.6,      3]  # orac-07.0-3000.6-py3
-          - [gentoo/stage3,  latest,   3000.6,      3]  # gent-late-3000.6-py3
-          - [gentoo/stage3, systemd,   3000.6,      3]  # gent-sysd-3000.6-py3
-          ### `3000.6-py2`
-          - [ubuntu       ,   18.04,   3000.6,      2]  # ubun-18.0-3000.6-py2
-          - [ubuntu       ,   16.04,   3000.6,      2]  # ubun-16.0-3000.6-py2
-          - [arch-base    ,  latest,   3000.6,      2]  # arch-late-3000.6-py2
+          # [os           ,  os_ver, salt_ver, py_ver]
+          - [0            ,    0   ,      0  ,      0]
 
         # Use this to start adopting the latest `platforms` (after Tiamat)
         platforms_new_inc_tiamat: &platforms_new_inc_tiamat
-          ### `tiamat-py3`
-          - [debian       ,   10   ,   tiamat,      3]
-          - [debian       ,    9   ,   tiamat,      3]
-          - [ubuntu       ,   20.04,   tiamat,      3]
-          - [ubuntu       ,   18.04,   tiamat,      3]
-          - [ubuntu       ,   16.04,   tiamat,      3]
-          - [centos       ,    8   ,   tiamat,      3]
-          - [centos       ,    7   ,   tiamat,      3]
-          - [amazonlinux  ,    2   ,   tiamat,      3]
-          # - [oraclelinux  ,    8   ,   tiamat,      3]
-          # - [oraclelinux  ,    7   ,   tiamat,      3]
-
-          ### `master-py3`
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   20.04,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [centos       ,    8   ,   master,      3]
-          - [fedora       ,   32   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [opensuse/leap,   15.2 ,   master,      3]
-          - [amazonlinux  ,    2   ,   master,      3]
-          # - [oraclelinux  ,    8   ,   master,      3]
-
-          ### `3001-py3`
-          - [debian       ,   10   ,   3001  ,      3]
-          - [debian       ,    9   ,   3001  ,      3]
-          - [ubuntu       ,   20.04,   3001  ,      3]
-          - [ubuntu       ,   18.04,   3001  ,      3]
-          - [centos       ,    8   ,   3001  ,      3]
-          - [centos       ,    7   ,   3001  ,      3]
-          - [fedora       ,   32   ,   3001  ,      3]
-          - [fedora       ,   31   ,   3001  ,      3]
-          - [opensuse/leap,   15.2 ,   3001  ,      3]
-          - [amazonlinux  ,    2   ,   3001  ,      3]
-          # - [oraclelinux  ,    8   ,   3001  ,      3]
-          # - [oraclelinux  ,    7   ,   3001  ,      3]
-
-          ### `3000.3-py3`
-          - [debian       ,   10   ,   3000.3,      3]
-          - [debian       ,    9   ,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      3]
-          - [centos       ,    8   ,   3000.3,      3]
-          - [centos       ,    7   ,   3000.3,      3]
-          - [fedora       ,   31   ,   3000.3,      3]
-          - [opensuse/leap,   15.2 ,   3000.3,      3]
-          - [amazonlinux  ,    2   ,   3000.3,      3]
-          ### ` 3000.3-py2`
-          - [ubuntu       ,   18.04,   3000.3,      2]
-          - [ubuntu       ,   16.04,   3000.3,      2]
-          - [arch-base    ,  latest,   3000.3,      2]
+          # [os           ,  os_ver, salt_ver, py_ver]
+          - [0            ,    0   ,      0  ,      0]
 
         # Use this to start adopting the latest `platforms`
         platforms_new: &platforms_new
-          ### `master-py3`
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   20.04,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [centos       ,    8   ,   master,      3]
-          - [fedora       ,   32   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [opensuse/leap,   15.2 ,   master,      3]
-          - [amazonlinux  ,    2   ,   master,      3]
-
-          ### `3000.3-py3`
-          - [debian       ,   10   ,   3000.3,      3]
-          - [debian       ,    9   ,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      3]
-          - [centos       ,    8   ,   3000.3,      3]
-          - [centos       ,    7   ,   3000.3,      3]
-          - [fedora       ,   31   ,   3000.3,      3]
-          - [opensuse/leap,   15.2 ,   3000.3,      3]
-          - [amazonlinux  ,    2   ,   3000.3,      3]
-          ### ` 3000.3-py2`
-          - [ubuntu       ,   18.04,   3000.3,      2]
-          - [ubuntu       ,   16.04,   3000.3,      2]
-          - [arch-base    ,  latest,   3000.3,      2]
-
-          ### `2019.2-py3`
-          - [debian       ,   10   ,   2019.2,      3]
-          - [debian       ,    9   ,   2019.2,      3]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          - [ubuntu       ,   16.04,   2019.2,      3]
-          - [centos       ,    8   ,   2019.2,      3]
-          - [centos       ,    7   ,   2019.2,      3]
-          - [fedora       ,   31   ,   2019.2,      3]
-          - [opensuse/leap,   15.2 ,   2019.2,      3]
-          - [amazonlinux  ,    2   ,   2019.2,      3]
-          ### `2019.2-py2`
-          - [centos       ,    6   ,   2019.2,      2]
-          - [amazonlinux  ,    1   ,   2019.2,      2]
-          - [arch-base    ,  latest,   2019.2,      2]
+          # [os           ,  os_ver, salt_ver, py_ver]
+          - [0            ,    0   ,      0  ,      0]
 
         # Use this to start adopting the "unified" platforms based on `saltimages`.
         # Based on `master` images primarily, until `tiamat` becomes viable
@@ -385,44 +222,18 @@ ssf_node_anchors:
 
         platforms_osfamily_debian: &platforms_osfamily_debian
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [debian       ,   10   ,   2019.2,      3]
-          - [debian       ,    9   ,   2019.2,      3]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          - [debian       ,    9   ,   2018.3,      2]
-          - [ubuntu       ,   16.04,   2018.3,      2]
-          - [debian       ,    8   ,   2017.7,      2]
-          - [ubuntu       ,   16.04,   2017.7,      2]
+          - [debian       ,    0   ,      0  ,      0]
+          - [ubuntu       ,    0   ,      0  ,      0]
         platforms_osfamily_debian_new: &platforms_osfamily_debian_new
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   20.04,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [debian       ,   10   ,   3000.3,      3]
-          - [debian       ,    9   ,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      2]
-          - [ubuntu       ,   16.04,   3000.3,      2]
-          - [debian       ,   10   ,   2019.2,      3]
-          - [debian       ,    9   ,   2019.2,      3]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          - [ubuntu       ,   16.04,   2019.2,      3]
+          - [debian       ,    0   ,      0  ,      0]
+          - [ubuntu       ,    0   ,      0  ,      0]
         platforms_osfamily_redhat: &platforms_osfamily_redhat
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [centos       ,    8   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [amazonlinux  ,    2   ,   master,      3]
-          - [centos       ,    8   ,   2019.2,      3]
-          - [fedora       ,   31   ,   2019.2,      3]
-          - [amazonlinux  ,    2   ,   2019.2,      3]
-          - [centos       ,    7   ,   2019.2,      2]
-          - [fedora       ,   30   ,   2018.3,      3]
-          - [centos       ,    7   ,   2018.3,      2]
-          - [amazonlinux  ,    1   ,   2018.3,      2]
-          - [centos       ,    6   ,   2017.7,      2]
-          - [fedora       ,   30   ,   2017.7,      2]
-          - [amazonlinux  ,    1   ,   2017.7,      2]
+          - [centos       ,    0   ,      0  ,      0]
+          - [fedora       ,    0   ,      0  ,      0]
+          - [amazonlinux  ,    0   ,      0  ,      0]
+          - [oraclelinux  ,    0   ,      0  ,      0]
         platforms_osfamily_redhat_new: &platforms_osfamily_redhat_new
           # [os           ,  os_ver, salt_ver, py_ver]
           - [centos       ,    8   ,   master,      3]
@@ -440,64 +251,43 @@ ssf_node_anchors:
           - [centos       ,    6   ,   2019.2,      2]
           - [amazonlinux  ,    1   ,   2019.2,      2]
         # yamllint disable-line rule:line-length
+        platforms_osfamily_redhat_without_fedora: &platforms_osfamily_redhat_without_fedora
+          # [os           ,  os_ver, salt_ver, py_ver]
+          - [centos       ,    0   ,      0  ,      0]
+          # # - [fedora       ,    0   ,      0  ,      0]
+          - [amazonlinux  ,    0   ,      0  ,      0]
+          - [oraclelinux  ,    0   ,      0  ,      0]
+        # yamllint disable-line rule:line-length
         platforms_osfamily_redhat_new_without_amazon: &platforms_osfamily_redhat_new_without_amazon
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [centos       ,    8   ,   master,      3]
-          - [fedora       ,   32   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [centos       ,    8   ,   3000.3,      3]
-          - [centos       ,    7   ,   3000.3,      3]
-          - [fedora       ,   31   ,   3000.3,      3]
-          - [centos       ,    8   ,   2019.2,      3]
-          - [centos       ,    7   ,   2019.2,      3]
-          - [fedora       ,   31   ,   2019.2,      3]
-          - [centos       ,    6   ,   2019.2,      2]
+          - [centos       ,    0   ,      0  ,      0]
+          - [fedora       ,    0   ,      0  ,      0]
+          - [oraclelinux  ,    0   ,      0  ,      0]
         platforms_osfamily_suse: &platforms_osfamily_suse
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [opensuse/leap,   15.1 ,   master,      3]
-          - [opensuse/leap,   15.1 ,   2019.2,      3]
-          - [opensuse/leap,   15.1 ,   2018.3,      2]
-          - [opensuse/leap,   15.1 ,   2017.7,      2]
+          - [opensuse/leap,    0   ,      0  ,      0]
+          - [opensuse/tmbl,    0   ,      0  ,      0]
         platforms_osfamily_suse_new: &platforms_osfamily_suse_new
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [opensuse/leap,   15.1 ,   master,      3]
-          - [opensuse/leap,   15.1 ,   3000.3,      3]
-          - [opensuse/leap,   15.1 ,   2019.2,      3]
-          - [opensuse/leap,   15.1 ,   2018.3,      2]
+          - [opensuse/leap,    0   ,      0  ,      0]
+          - [opensuse/tmbl,    0   ,      0  ,      0]
+        # TODO: Rename accordingly
         platforms_osfamily_suse_new_15_2: &platforms_osfamily_suse_new_15_2
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [opensuse/leap,   15.2 ,   master,      3]
-          - [opensuse/leap,   15.2 ,   3000.3,      3]
-          - [opensuse/leap,   15.2 ,   2019.2,      3]
+          - [opensuse/leap,    0   ,      0  ,      0]
+          - [opensuse/tmbl,    0   ,      0  ,      0]
         platforms_os_debian: &platforms_os_debian
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [debian       ,   10   ,   master,      3]
-          - [debian       ,   10   ,   2019.2,      3]
-          - [debian       ,    9   ,   2019.2,      3]
-          - [debian       ,    9   ,   2018.3,      2]
-          - [debian       ,    8   ,   2017.7,      2]
+          - [debian       ,    0   ,      0  ,      0]
         platforms_os_debian_new: &platforms_os_debian_new
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [debian       ,   10   ,   master,      3]
-          - [debian       ,   10   ,   3000.3,      3]
-          - [debian       ,    9   ,   3000.3,      3]
-          - [debian       ,   10   ,   2019.2,      3]
-          - [debian       ,    9   ,   2019.2,      3]
+          - [debian       ,    0   ,      0  ,      0]
         platforms_os_ubuntu: &platforms_os_ubuntu
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          - [ubuntu       ,   16.04,   2018.3,      2]
-          - [ubuntu       ,   16.04,   2017.7,      2]
+          - [ubuntu       ,    0   ,      0  ,      0]
         platforms_os_ubuntu_new: &platforms_os_ubuntu_new
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [ubuntu       ,   20.04,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [ubuntu       ,   18.04,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      2]
-          - [ubuntu       ,   16.04,   3000.3,      2]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          - [ubuntu       ,   16.04,   2019.2,      3]
+          - [ubuntu       ,    0   ,      0  ,      0]
         # platforms_os_ubuntu18: &platforms_os_ubuntu18
         #   # [os           ,  os_ver, salt_ver, py_ver]
         #   - [ubuntu       ,   18.04,   master,      3]
@@ -514,10 +304,7 @@ ssf_node_anchors:
           - [fedora       ,   30   ,   2017.7,      2]
         platforms_os_fedora_new: &platforms_os_fedora_new
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [fedora       ,   32   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [fedora       ,   31   ,   3000.3,      3]
-          - [fedora       ,   31   ,   2019.2,      3]
+          - [fedora       ,    0   ,      0  ,      0]
         # platforms_os_suse: &platforms_os_suse
         #   # [os           ,  os_ver, salt_ver, py_ver]
         #   - [opensuse/leap,   15.1 ,   master,      3]
@@ -547,35 +334,25 @@ ssf_node_anchors:
           - [amazonlinux  ,    1   ,   2017.7,      2]
         platforms_os_amazonlinux_new: &platforms_os_amazonlinux_new
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [amazonlinux  ,    2   ,   master,      3]
-          - [amazonlinux  ,    2   ,   3000.3,      3]
-          - [amazonlinux  ,    2   ,   2019.2,      3]
-          - [amazonlinux  ,    1   ,   2019.2,      2]
+          - [amazonlinux  ,    0   ,      0  ,      0]
         platforms_os_upstart: &platforms_os_upstart
           # [os           ,  os_ver, salt_ver, py_ver]
           - [centos       ,    6   ,   2019.2,      2]
           - [amazonlinux  ,    1   ,   2019.2,      2]
         platforms_os_arch_base: &platforms_os_arch_base
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [arch-base    ,  latest,   2019.2,      2]
-          - [arch-base    ,  latest,   2018.3,      2]
-          - [arch-base    ,  latest,   2017.7,      2]
+          - [arch-base    ,  latest,      0  ,      0]
         platforms_os_arch_base_new: &platforms_os_arch_base_new
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [arch-base    ,  latest,   3000.3,      2]
-          - [arch-base    ,  latest,   2019.2,      2]
+          - [arch-base    ,    0   ,      0  ,      0]
         platforms_os_redhat_locale_specific: &platforms_os_redhat_locale_specific
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [centos       ,    8   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [amazonlinux  ,    2   ,   master,      3]
-          - [centos       ,    8   ,   2019.2,      3]
-          - [fedora       ,   31   ,   2019.2,      3]
-          - [amazonlinux  ,    2   ,   2019.2,      3]
-          - [fedora       ,   30   ,   2018.3,      3]
-          - [amazonlinux  ,    1   ,   2018.3,      2]
-          - [fedora       ,   30   ,   2017.7,      2]
-          - [amazonlinux  ,    1   ,   2017.7,      2]
+          # # - [centos       ,    0   ,      0  ,      0]
+          - [centos       ,    8   ,      0  ,      0]
+          - [fedora       ,    0   ,      0  ,      0]
+          - [amazonlinux  ,    0   ,      0  ,      0]
+          # # - [oraclelinux  ,    0   ,      0  ,      0]
+          - [oraclelinux  ,    8   ,      0  ,      0]
         platforms_2017_7: &platforms_2017_7
           # [os           ,  os_ver, salt_ver, py_ver]
           # - [debian       ,    9   ,   2017.7,      2]
@@ -588,22 +365,13 @@ ssf_node_anchors:
           - [arch-base    ,  latest,   2017.7,      2]
         platforms_gentoo: &platforms_gentoo
           # [os           ,  os_ver, salt_ver, py_ver]
-          - [gentoo/stage3,  latest,   master,      3]
-          - [gentoo/stage3, systemd,   master,      3]
-          - [gentoo/stage3,  latest,   3001  ,      3]
-          - [gentoo/stage3, systemd,   3001  ,      3]
-          - [gentoo/stage3,  latest,   3000.3,      3]
-          - [gentoo/stage3, systemd,   3000.3,      3]
+          - [gentoo/stage3,    0   ,      0  ,      0]
+        # TODO: Rename because includes Gentoo
         platforms_non_systemd: &platforms_non_systemd
           # [os           ,  os_ver, salt_ver, py_ver]
           - [centos       ,    6   ,   2019.2,      2]
           - [amazonlinux  ,    1   ,   2019.2,      2]
-          - [gentoo/stage3,  latest,   master,      3]
-          - [gentoo/stage3, systemd,   master,      3]
-          - [gentoo/stage3,  latest,   3001  ,      3]
-          - [gentoo/stage3, systemd,   3001  ,      3]
-          - [gentoo/stage3,  latest,   3000.3,      3]
-          - [gentoo/stage3, systemd,   3000.3,      3]
+          - [gentoo/stage3,    0   ,      0  ,      0]
         platforms_matrix_osfamily_suites: &platforms_matrix_osfamily_suites
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [debian       ,   10   ,   master,      3,          debian]
@@ -614,19 +382,25 @@ ssf_node_anchors:
           - [centos       ,    6   ,   2017.7,      2,          redhat]
         platforms_matrix_osfamily_debian: &platforms_matrix_osfamily_debian
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          # # - [debian       ,    9   ,   2018.3,      2,         default]
-          # # - [ubuntu       ,   16.04,   2017.7,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
         platforms_matrix_osfamily_debian_new: &platforms_matrix_osfamily_debian_new
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [debian       ,    9   ,   3000.3,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [ubuntu       ,   16.04,   2019.2,      3,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+        platforms_matrix_osfamily_redhat: &platforms_matrix_osfamily_redhat
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+        # yamllint disable-line rule:line-length
+        platforms_matrix_osfamily_redhat_without_fedora: &platforms_matrix_osfamily_redhat_without_fedora
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [centos       ,    0   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
         platforms_matrix_systemd_only: &platforms_matrix_systemd_only
           # TODO: Get `centos-8` working again and re-enable
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
@@ -639,13 +413,16 @@ ssf_node_anchors:
           - [arch-base    ,  latest,   2018.3,      2,         default]
         platforms_matrix_without_arch: &platforms_matrix_without_arch
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [opensuse/leap,   15.1 ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          # - [arch-base    ,  latest,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         platforms_matrix_without_arch_new: &platforms_matrix_without_arch_new
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [debian       ,   10   ,   master,      3,         default]
@@ -655,13 +432,114 @@ ssf_node_anchors:
           - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
           - [amazonlinux  ,    2   ,   3000.3,      3,         default]
           # - [arch-base    ,  latest,   2019.2,      2,         default]
+        # yamllint disable-line rule:line-length
+        platforms_matrix_without_arch_and_gentoo: &platforms_matrix_without_arch_and_gentoo
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
+        # yamllint disable-line rule:line-length
+        platforms_matrix_without_arch_and_tumbleweed: &platforms_matrix_without_arch_and_tumbleweed
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
+        platforms_matrix_without_gentoo: &platforms_matrix_without_gentoo
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
+        # yamllint disable-line rule:line-length
+        platforms_matrix_without_gentoo_non_systemd: &platforms_matrix_without_gentoo_non_systemd
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [gentoo/stage3, systemd,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
+        # yamllint disable-line rule:line-length
+        platforms_matrix_without_centos_and_oracle: &platforms_matrix_without_centos_and_oracle
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
+        platforms_matrix_without_rhel8: &platforms_matrix_without_rhel8
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,         default]
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
+        # yamllint disable-line rule:line-length
+        platforms_matrix_without_rhel8_and_gentoo: &platforms_matrix_without_rhel8_and_gentoo
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         platforms_matrix_jetbrains: &platforms_matrix_jetbrains
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          # # - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,            arch]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          - [fedora       ,   32   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,            arch]
         # yamllint disable-line rule:line-length
         travis_do_not_use_single_job_for_linters: &travis_do_not_use_single_job_for_linters
           use_single_job_for_linters: false
@@ -808,39 +686,23 @@ ssf:
                     - .config.certificates
                     - .config.modules.mod_security
                     - .config.modules.server_status
-          2:
-            inspec_yml:
-              summary: >-
-                Verify that the apache formula manages modules correctly
-            includes: *platforms_os_arch_base
-            # includes: *platforms_os_arch_base_new
-            provisioner:
-              pillars_from_files:
-                - .sls: 'test/salt/pillar/modules.sls'
-              state_top:
-                - '*':
-                    - .
-                    - .config.modules
-                    - .config.certificates
-                    - .config.modules.mod_security
-                    - .config.modules.server_status
-            verifier:
-              inspec_tests:
-                - nomodsecurity
+          2: {}
         inspec_suites_matrix:
           - default
           - modules
-          - arch
+          - ''
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         modules]
-          - [centos       ,    8   ,   master,      3,         modules]
-          - [fedora       ,   31   ,   master,      3,         modules]
-          - [opensuse/leap,   15.1 ,   master,      3,         modules]
-          - [amazonlinux  ,    2   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         modules]
-          - [centos       ,    7   ,   2019.2,      2,         modules]
-          - [arch-base    ,  latest,   2017.7,      2,            arch]
+          - [debian       ,   10   ,   master,      3,              '']  # modules
+          - [ubuntu       ,    0   ,   master,      0,              '']  # modules
+          - [centos       ,    0   ,   master,      0,              '']  # modules
+          - [fedora       ,    0   ,   master,      0,              '']  # modules
+          - [opensuse/leap,    0   ,   master,      0,              '']  # modules
+          - [opensuse/tmbl,    0   ,   master,      0,         default]  # POSSIBLE
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,              '']  # modules
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         modules]  # POSSIBLE
         use_tofs: true
         yamllint:
           ignore:
@@ -898,23 +760,12 @@ ssf:
           - preferences
           - unattended
           - ''
-        platforms:
-          # [os           ,  os_ver, salt_ver, py_ver]
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          # - [debian       ,   10   ,   2019.2,      3]
-          - [debian       ,    9   ,   2019.2,      3]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          # - [debian       ,    9   ,   2018.3,      2]
-          # - [ubuntu       ,   16.04,   2018.3,      2]
-          # - [debian       ,    8   ,   2017.7,      2]
-          # - [ubuntu       ,   16.04,   2017.7,      2]
+        platforms: *platforms_osfamily_debian
+        # Based on `*platforms_matrix_osfamily_debian`
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,    repositories]
-          - [ubuntu       ,   18.04,   master,      3,    repositories]
-          - [debian       ,    9   ,   2019.2,      3,     preferences]
-          - [ubuntu       ,   18.04,   2019.2,      3,      unattended]
+          - [debian       ,    0   ,   master,      0,              '']
+          - [ubuntu       ,    0   ,   master,      0,              '']
       semrel_files: *semrel_files_default
     apt-cacher:
       context:
@@ -934,6 +785,7 @@ ssf:
                 - '*':
                     - .ng.server
                     - .ng.client
+        platforms: *platforms_osfamily_debian
         platforms_matrix: *platforms_matrix_osfamily_debian
         use_tofs: true
       semrel_files:
@@ -1041,58 +893,13 @@ ssf:
           # - workbench2
           # - dispatcher
         platforms:
-          # Based on *platforms_new_inc_tiamat
-          ### `tiamat-py3`
-          - [debian       ,   10   ,   tiamat,      3]
-          - [debian       ,    9   ,   tiamat,      3]
-          - [ubuntu       ,   20.04,   tiamat,      3]
-          - [ubuntu       ,   18.04,   tiamat,      3]
-          # # - [ubuntu       ,   16.04,   tiamat,      3]
-          # # - [centos       ,    8   ,   tiamat,      3]
-          - [centos       ,    7   ,   tiamat,      3]
-          # # - [amazonlinux  ,    2   ,   tiamat,      3]
-          # # - [oraclelinux  ,    8   ,   tiamat,      3]
-          # # - [oraclelinux  ,    7   ,   tiamat,      3]
-
-          ### `master-py3`
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   20.04,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          # # - [centos       ,    8   ,   master,      3]
-          # # - [fedora       ,   32   ,   master,      3]
-          # # - [fedora       ,   31   ,   master,      3]
-          # # - [opensuse/leap,   15.2 ,   master,      3]
-          # # - [amazonlinux  ,    2   ,   master,      3]
-          # # - [oraclelinux  ,    8   ,   master,      3]
-
-          ### `3001-py3`
-          - [debian       ,   10   ,   3001  ,      3]
-          - [debian       ,    9   ,   3001  ,      3]
-          - [ubuntu       ,   20.04,   3001  ,      3]
-          - [ubuntu       ,   18.04,   3001  ,      3]
-          # # - [centos       ,    8   ,   3001  ,      3]
-          - [centos       ,    7   ,   3001  ,      3]
-          # # - [fedora       ,   32   ,   3001  ,      3]
-          # # - [fedora       ,   31   ,   3001  ,      3]
-          # # - [opensuse/leap,   15.2 ,   3001  ,      3]
-          # # - [amazonlinux  ,    2   ,   3001  ,      3]
-          # # - [oraclelinux  ,    8   ,   3001  ,      3]
-          # # - [oraclelinux  ,    7   ,   3001  ,      3]
-
-          ### `3000.3-py3`
-          - [debian       ,   10   ,   3000.3,      3]
-          - [debian       ,    9   ,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      3]
-          # # - [centos       ,    8   ,   3000.3,      3]
-          - [centos       ,    7   ,   3000.3,      3]
-          # # - [fedora       ,   31   ,   3000.3,      3]
-          # # - [opensuse/leap,   15.2 ,   3000.3,      3]
-          # # - [amazonlinux  ,    2   ,   3000.3,      3]
-          ### ` 3000.3-py2`
-          - [ubuntu       ,   18.04,   3000.3,      2]
-          # # - [ubuntu       ,   16.04,   3000.3,      2]
-          # # - [arch-base    ,  latest,   3000.3,      2]
+          # [os           ,  os_ver, salt_ver, py_ver]
+          - [debian       ,    0   ,      0  ,      0]
+          - [ubuntu       ,    0   ,      0  ,      0]
+          - [centos       ,    0   ,      0  ,      0]
         platforms_matrix:
+          # # NOT TOUCHING THIS FORMULA, LEAVING IT FOR JAVIER
+          # # Custom `kitchen.yml` as well, which makes it difficult
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           # # - [ubuntu       ,   18.04,   master,      3,       workbench]
           # # - [debian       ,   10   ,   3001  ,      3,             api]
@@ -1133,7 +940,19 @@ ssf:
                 - '*':
                     - .
                     - .config
-        platforms_matrix: *platforms_matrix_without_arch
+        # Based on `*platforms_matrix_without_arch`
+        platforms_matrix:
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         travis: *travis_do_not_use_single_job_for_linters
         yamllint:
           rules:
@@ -1162,6 +981,7 @@ ssf:
                 - '*':
                     - states/setup-certs-to-remove
                     - .
+        platforms_matrix: *platforms_matrix_without_gentoo
         travis: *travis_do_not_use_single_job_for_linters
       semrel_files: *semrel_files_default
     chrony:
@@ -1174,6 +994,7 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the chrony formula is setup and configured correctly
+        platforms_matrix: *platforms_matrix_without_centos_and_oracle
         use_tofs: true
       semrel_files: *semrel_files_default
     collectd:
@@ -1189,16 +1010,19 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/default/pillar/collectd.sls'
+        # Based on `*platforms_matrix_without_arch_and_gentoo`
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          # - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          # - [arch-base    ,  latest,   2019.2,      2,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
       semrel_files: *semrel_files_default
     consul:
       context:
@@ -1219,7 +1043,7 @@ ssf:
                 - base.sls: 'pillar.example'
                 - .sls: 'test/salt/pillar/default.sls'
         platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_new
+        platforms_matrix: *platforms_matrix_without_gentoo_non_systemd
       semrel_files: *semrel_files_default
     cron:
       context:
@@ -1239,6 +1063,7 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/cron.sls'
+        platforms_matrix: *platforms_matrix_without_gentoo
       semrel_files: *semrel_files_default
     deepsea:
       context:
@@ -1257,19 +1082,17 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          # # `make install` fails, unable to locate `salt-api` & `python3-tox`
-          # # - [ubuntu       ,   20.04,   master,      3,         default]
-          # # - [ubuntu       ,   18.04,   master,      3,         default]
-          # # - [centos       ,    8   ,   master,      3,         default]
-          # # - [fedora       ,   32   ,   master,      3,         default]
-          # # `make install` fails
-          # # - [opensuse/leap,   15.2 ,   master,      3,         default]
-          # # - [debian       ,    9   ,   3000.3,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          # # - [centos       ,    7   ,   3000.3,      3,         default]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
-          # # - [fedora       ,   31   ,   2019.2,      3,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     devstack:
@@ -1294,13 +1117,7 @@ ssf:
         platforms: *platforms_os_ubuntu_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          # # - [ubuntu       ,   20.04,   master,      3,          ubuntu]
-          - [ubuntu       ,   18.04,   master,      3,          ubuntu]
-          # - [ubuntu       ,   18.04,   3000.3,      3,          ubuntu]
-          - [ubuntu       ,   18.04,   3000.3,      2,          ubuntu]
-          # # - [ubuntu       ,   16.04,   3000.3,      2,          ubuntu]
-          # - [ubuntu       ,   18.04,   2019.2,      3,          ubuntu]
-          # # - [ubuntu       ,   16.04,   2019.2,      3,          ubuntu]
+          - [ubuntu       ,   18.04,      0  ,      0,          ubuntu]
         use_libsaltcli: true
         use_tofs: true
         yamllint:
@@ -1335,16 +1152,18 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          # - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,         default]
-          - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          # Was working but file comparison now tripping up on spaces on empty lines
-          # - [centos       ,    7   ,   2019.2,      3,         default]
-          # # - [centos       ,    6   ,   2019.2,      2,         default]
-          # - [arch-base    ,  latest,   2019.2,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,         default]
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
       semrel_files: *semrel_files_inc_map_jinja_verifier
     django:
       context:
@@ -1360,6 +1179,20 @@ ssf:
               state_top:
                 - '*':
                     - .pip
+        # Based on `*platforms_matrix_without_gentoo`
+        platforms_matrix:
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          - [fedora       ,   32   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
       semrel_files: *semrel_files_default
     docker:
       context:
@@ -1437,19 +1270,8 @@ ssf:
           - cpp
           - javascript
         platforms: *platforms_new
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          # # - [debian       ,   10   ,   master,      3,            java]
-          # # - [centos       ,    8   ,   master,      3,            java]
-          # # - [fedora       ,   32   ,   master,      3,      javascript]
-          # # - [opensuse/leap,   15.2 ,   master,      3,             cpp]
-          # - [ubuntu       ,   18.04,   3000.3,      3,             cpp]
-          - [arch-base    ,  latest,   2019.2,      2,            java]
-        # To deal with excessive instances when mimicking `kitchen list -b`
-        # If values are set, only use these as commented entries in the matrix
-        platforms_matrix_commented_includes:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,            java]
+        # Linux testing no longer working
+        platforms_matrix: []
         use_tofs: true
         yamllint:
           ignore:
@@ -1466,20 +1288,12 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the epel formula is setup and configured correctly
-              supports: *supports_centos_fedora_amazon
+              supports: *supports_centos_amazon_oracle
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/default.sls'
-        platforms: *platforms_osfamily_redhat
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [centos       ,    8   ,   master,      3,         default]
-          # - [fedora       ,   31   ,   master,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [centos       ,    7   ,   2019.2,      2,         default]
-          # - [fedora       ,   30   ,   2018.3,      3,         default]
-          # # - [amazonlinux  ,    1   ,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+        platforms: *platforms_osfamily_redhat_without_fedora
+        platforms_matrix: *platforms_matrix_osfamily_redhat_without_fedora
       semrel_files: *semrel_files_default
     exim:
       context:
@@ -1491,7 +1305,6 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the exim formula is setup and configured correctly
-              supports: *supports_debian_ubuntu
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/exim.sls'
@@ -1520,17 +1333,7 @@ ssf:
                 - '*':
                     - misc.fake_log_files
                     - .
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          # - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          # - [fedora       ,   30   ,   2018.3,      3,         default]
-          - [centos       ,    7   ,   2018.3,      2,         default]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+        platforms_matrix: *platforms_matrix_without_gentoo_non_systemd
       semrel_files: *semrel_files_default
     firewalld:
       context:
@@ -1549,15 +1352,22 @@ ssf:
         map_jinja:
           verification:
             import: ['firewalld']
+        # Based on `*platforms_matrix_without_gentoo`
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,         default]
-          - [arch-base    ,  latest,   2018.3,      2,         default]
-          # - [ubuntu       ,   16.04,   2017.7,      2,         default]
+          # # - [debian       ,    0   ,   master,      0,         default]
+          - [debian       ,    9   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   18.04,   master,      0,         default]
+          - [ubuntu       ,   16.04,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
       semrel_files: *semrel_files_inc_map_jinja_verifier
     golang:
       context:
@@ -1585,15 +1395,22 @@ ssf:
         inspec_suites_matrix:
           - default
           - package
+          - ''
         platforms: *platforms_new
         platforms_matrix:
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         package]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         package]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
-          - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         package]
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,              '']
+          - [ubuntu       ,    0   ,   master,      0,              '']
+          # # - [centos       ,    0   ,   master,      0,              '']
+          - [centos       ,    8   ,   master,      0,              '']
+          - [centos       ,    7   ,   master,      0,         package]
+          - [fedora       ,    0   ,   master,      0,              '']
+          - [opensuse/leap,    0   ,   master,      0,              '']
+          - [opensuse/tmbl,    0   ,   master,      0,              '']
+          - [amazonlinux  ,    0   ,   master,      0,              '']
+          - [oraclelinux  ,    0   ,   master,      0,              '']
+          # # - [gentoo/stage3,    0   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   3002.2,      0,              '']
         use_tofs: true
       semrel_files: *semrel_files_default
     grafana:
@@ -1633,14 +1450,14 @@ ssf:
                     - hosts
                     - .
               pillars_from_files:
-                - .sls: 'pillar.example'
                 - hosts.sls: 'test/salt/pillar/hosts.sls'
+                - .sls: 'test/salt/pillar/default.sls'
               state_top:
                 - '*':
                     - hosts
                     - .
         platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_osfamily_debian_new
+        platforms_matrix: *platforms_matrix_without_gentoo
         yamllint:
           ignore:
             additional:
@@ -1703,7 +1520,7 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/influxdb.sls'
-        platforms_matrix: *platforms_matrix_without_arch
+        platforms_matrix: *platforms_matrix_without_arch_and_gentoo
       semrel_files: *semrel_files_default
     iptables:
       context:
@@ -1734,20 +1551,26 @@ ssf:
                 - '*':
                     - .
                     - .tables
+          2: {}
         inspec_suites_matrix:
           - default
           - tables
+          - ''
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          - [centos       ,    7   ,   2018.3,      2,         default]
-          # - [centos       ,    6   ,   2017.7,      2,         default]
-          - [opensuse/leap,   15.1 ,   2017.7,      2,          tables]
-        travis: *travis_do_not_use_single_job_for_linters
+          - [debian       ,   10   ,   master,      0,         default]
+          - [debian       ,    9   ,   master,      0,              '']
+          - [ubuntu       ,    0   ,   master,      0,              '']
+          - [centos       ,    8   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,              '']
+          - [fedora       ,    0   ,   master,      0,              '']
+          - [opensuse/leap,    0   ,   master,      0,              '']
+          - [opensuse/tmbl,    0   ,   master,      0,              '']
+          - [amazonlinux  ,    0   ,   master,      0,              '']
+          - [oraclelinux  ,    8   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,              '']
+          - [gentoo/stage3,    0   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   3002.2,      0,              '']
         yamllint:
           rules:
             key-duplicates:
@@ -1764,25 +1587,9 @@ ssf:
             repo: 'iscsi-formula'
         inspec_suites_kitchen:
           0:
-            excludes:
-              # [os           ,  os_ver, salt_ver, py_ver]
-              # `*platforms_osfamily_redhat_new` & `*platforms_os_arch_base_new`
-              - [centos       ,    8   ,   master,      3]
-              - [fedora       ,   32   ,   master,      3]
-              - [fedora       ,   31   ,   master,      3]
-              - [amazonlinux  ,    2   ,   master,      3]
-              - [centos       ,    8   ,   3000.3,      3]
-              - [centos       ,    7   ,   3000.3,      3]
-              - [fedora       ,   31   ,   3000.3,      3]
-              - [amazonlinux  ,    2   ,   3000.3,      3]
-              - [arch-base    ,  latest,   3000.3,      2]
-              - [centos       ,    8   ,   2019.2,      3]
-              - [centos       ,    7   ,   2019.2,      3]
-              - [fedora       ,   31   ,   2019.2,      3]
-              - [amazonlinux  ,    2   ,   2019.2,      3]
-              - [centos       ,    6   ,   2019.2,      2]
-              - [amazonlinux  ,    1   ,   2019.2,      2]
-              - [arch-base    ,  latest,   2019.2,      2]
+            # Removed for now, until CI re-established, was based on:
+            # `*platforms_osfamily_redhat_new` & `*platforms_os_arch_base_new`
+            # excludes:
             inspec_yml:
               summary: >-
                 Verify that the iscsi formula is setup and configured correctly
@@ -1860,15 +1667,8 @@ ssf:
           - redhat
           - arch
         platforms: *platforms_new
-        # Linux testing not working on GitLab CI yet, last matrix shown below
+        # Linux testing no longer working, due to `lvm-formula` dependency
         platforms_matrix: []
-        # # # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-        # # - [ubuntu       ,   18.04,   master,      3,         default]
-        # # - [centos       ,    8   ,   master,      3,          redhat]
-        # # - [fedora       ,   32   ,   master,      3,          redhat]
-        # # - [opensuse/leap,   15.2 ,   master,      3,         default]
-        # # - [amazonlinux  ,    2   ,   master,      3,          redhat]
-        # # # # - [arch-base    ,  latest,   3000.3,      2,            arch]
         use_tofs: true
         yamllint:
           ignore:
@@ -1950,6 +1750,8 @@ ssf:
           verification:
             import: ['mapdata']
         platforms_matrix:
+          # TODO: Going to need to fix `libcimatrix.jinja` to allow multipe
+          #       suites per specific platform
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [ubuntu       ,    0   ,   master,      0,           adopt]
           - [ubuntu       ,    0   ,   master,      0,          amazon]
@@ -2212,7 +2014,22 @@ ssf:
           - default
           - arch
         platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_jetbrains
+        # Based on `*platforms_matrix_jetbrains`
+        platforms_matrix:
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          - [fedora       ,   32   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,            arch]
         use_tofs: true
         yamllint:
           ignore:
@@ -2324,7 +2141,9 @@ ssf:
           - default
           - arch
         platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_jetbrains
+        # No Linux testing now, currently broken in `map.jinja`
+        platforms_matrix: []
+        # platforms_matrix: *platforms_matrix_jetbrains
         use_tofs: true
         yamllint:
           ignore:
@@ -2363,13 +2182,6 @@ ssf:
                     - .clean
                     - .
         platforms: *platforms_new
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
         use_tofs: true
       semrel_files:
         <<: *semrel_files_default
@@ -2560,15 +2372,7 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the keepalived formula is setup and configured correctly
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          # # - [opensuse/leap,   15.1 ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          # # - [fedora       ,   30   ,   2018.3,      3,         default]
-          # # - [arch-base    ,  latest,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+        platforms_matrix: *platforms_matrix_without_arch_and_tumbleweed
         # TODO: Find appropriate use of `script_kitchen` & `travis` sections below
         script_kitchen:
           pre:
@@ -2591,9 +2395,6 @@ ssf:
             repo: 'letsencrypt-formula'
         inspec_suites_kitchen:
           0:
-            # `2017.7` don't have the `git.cloned` state so will have to use one of
-            # the other suites
-            excludes: *platforms_2017_7
             inspec_yml:
               summary: >-
                 Verify that the letsencrypt formula is setup and configured correctly
@@ -2655,13 +2456,18 @@ ssf:
           - rpm
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,             deb]
-          - [ubuntu       ,   18.04,   2019.2,      3,             git]
-          - [centos       ,    8   ,   2019.2,      3,             git]
-          - [amazonlinux  ,    2   ,   2019.2,      3,             rpm]
-          - [arch-base    ,  latest,   2019.2,      2,             git]
-          - [fedora       ,   30   ,   2018.3,      3,             git]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,             git]
+          - [debian       ,    0   ,   master,      0,             deb]
+          - [ubuntu       ,    0   ,   master,      0,             deb]
+          - [centos       ,    0   ,   master,      0,             rpm]
+          - [fedora       ,    0   ,   master,      0,             rpm]
+          - [opensuse/leap,    0   ,   master,      0,             git]
+          - [opensuse/tmbl,    0   ,   master,      0,             git]
+          - [amazonlinux  ,    0   ,   master,      0,             rpm]
+          # # Should work but failing dependency resolution
+          # # - [oraclelinux  ,    0   ,   master,      0,             rpm]
+          - [oraclelinux  ,    8   ,   master,      0,             rpm]
+          - [gentoo/stage3,    0   ,   master,      0,             git]
+          - [arch-base    ,    0   ,   3002.2,      0,             git]
       semrel_files: *semrel_files_default
     libvirt:
       context:
@@ -2696,32 +2502,24 @@ ssf:
                     - .clean
         inspec_suites_matrix:
           - default
-          - share
           - clean
         platforms: *platforms_new_saltimages
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [debian       ,   10   ,   master,      3,           clean]
-          - [debian       ,    9   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          # - [ubuntu       ,   18.04,   master,      3,         default]
-          # - [ubuntu       ,   16.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          # - [centos       ,    7   ,   master,      3,         default]
-          # # Only fails at the verification stage (can't connect via. SSH)
-          # # Using `fedora-32` instead in the meantime
-          # # https://gitlab.com/myii/libvirt-formula/-/jobs/995148177
-          # # - [fedora       ,   33   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,         default]
+          - [debian       ,    9   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          # Just started failing:
+          # - https://gitlab.com/myii/libvirt-formula/-/jobs/1043414281
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           # Can be enabled soon once InSpec packages check is fixed
-          # - [opensuse/tmbl,  latest,   master,      3,         default]
-          # # - [amazonlinux  ,    2   ,   master,      3,         default]
-          # # - [oraclelinux  ,    8   ,   master,      3,         default]
-          # # - [oraclelinux  ,    7   ,   master,      3,         default]
-          # # - [gentoo/stage3,  latest,   master,      3,         default]
-          # # - [gentoo/stage3, systemd,   master,      3,         default]
-          # # - [arch-base    ,  latest,   3000.6,      2,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_libsaltcli: true
         use_tofs: true
       semrel_files:
@@ -2752,13 +2550,26 @@ ssf:
           - redhat
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,          redhat]
-          - [amazonlinux  ,    2   ,   2019.2,      3,          redhat]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,         default]
-          - [arch-base    ,  latest,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   20.04,   master,      0,         default]
+          - [ubuntu       ,   18.04,   master,      0,         default]
+          - [centos       ,    8   ,   master,      0,          redhat]
+          # RedHat-7 not working with the `redhat` suite, due to packages
+          # - `glibc-langpack-de` not available, `glibc-common` is sufficient
+          - [centos       ,    7   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,          redhat]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,          redhat]
+          - [oraclelinux  ,    8   ,   master,      0,          redhat]
+          # Beyond RedHat-7 issues, this doesn't work with the current Kitchen setup
+          # because only `en`-based locales are available
+          # - https://gitlab.com/myii/locale-formula/-/jobs/1039987126
+          # - https://gitlab.com/myii/locale-formula/-/jobs/1040056073
+          # # - [oraclelinux  ,    7   ,   master,      0,          redhat]
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
       semrel_files: *semrel_files_default
     logrotate:
       context:
@@ -2778,8 +2589,6 @@ ssf:
                 - '*':
                     - .
                     - .jobs
-        platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_without_arch_new
       semrel_files: *semrel_files_default
     lvm:
       context:
@@ -2820,46 +2629,8 @@ ssf:
         inspec_suites_matrix:
           - loop4-loop5
           - loop5-loop6
-        # Linux testing not working on GitLab CI yet, last matrix shown below
+        # Linux testing no longer working
         platforms_matrix: []
-        # # # Note, the commented lines are the only ones that didn't work
-        # # # Everything else working, even if lines have been removed
-        # # # Keeping hold of this "working out" for future reference
-        # # # One `#` where working but not using, two `# #` for not working at all
-        # # # Update: the lines the have been modified due to `2019.2.2` can no longer
-        # # #         be guaranteed (i.e. working or not)
-        # # # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-        # # - [ubuntu       ,   18.04,   master,      3,     loop5-loop6]
-        # # - [centos       ,    8   ,   master,      3,     loop5-loop6]
-        # # - [amazonlinux  ,    2   ,   2019.2,      3,     loop5-loop6]
-        # # - [opensuse/leap,   15.1 ,   2018.3,      2,     loop5-loop6]
-        # To deal with excessive instances when mimicking `kitchen list -b`
-        # If values are set, only use these as commented entries in the matrix
-        platforms_matrix_commented_includes:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,     loop5-loop6]
-          - [ubuntu       ,   18.04,   master,      3,     loop4-loop5]
-          - [ubuntu       ,   18.04,   master,      3,     loop5-loop6]
-          - [centos       ,    8   ,   master,      3,     loop5-loop6]
-          - [fedora       ,   31   ,   master,      3,     loop5-loop6]
-          - [opensuse/leap,   15.1 ,   master,      3,     loop5-loop6]
-          - [amazonlinux  ,    2   ,   master,      3,     loop5-loop6]
-          - [debian       ,   10   ,   2019.2,      3,     loop5-loop6]
-          - [debian       ,    9   ,   2019.2,      3,     loop5-loop6]
-          - [ubuntu       ,   18.04,   2019.2,      3,     loop5-loop6]
-          - [centos       ,    8   ,   2019.2,      3,     loop5-loop6]
-          - [fedora       ,   31   ,   2019.2,      3,     loop5-loop6]
-          - [opensuse/leap,   15.1 ,   2019.2,      3,     loop5-loop6]
-          - [centos       ,    7   ,   2019.2,      2,     loop5-loop6]
-          - [amazonlinux  ,    2   ,   2019.2,      3,     loop5-loop6]
-          - [arch-base    ,  latest,   2019.2,      2,     loop5-loop6]
-          - [fedora       ,   30   ,   2018.3,      3,     loop5-loop6]
-          - [debian       ,    9   ,   2018.3,      2,     loop5-loop6]
-          - [ubuntu       ,   16.04,   2018.3,      2,     loop5-loop6]
-          - [centos       ,    7   ,   2018.3,      2,     loop5-loop6]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,     loop5-loop6]
-          - [amazonlinux  ,    1   ,   2018.3,      2,     loop5-loop6]
-          - [arch-base    ,  latest,   2018.3,      2,     loop5-loop6]
       semrel_files: *semrel_files_default
     lynis:
       context:
@@ -2886,44 +2657,32 @@ ssf:
           #           - .
           1: *inspec_suites_kitchen__share_suite
           2:
-            excludes: *platforms_os_amazonlinux_new
             inspec_yml:
+              # depends: *depends_on_suite_share
               summary: >-
                 Verify that the lynis formula is setup and configured correctly
                 (installed as a package)
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/repo.sls'
-          3:
-            includes: *platforms_os_amazonlinux_new
-            provisioner:
-              dependencies: *dependencies_epel
-              pillars_from_files:
-                - .sls: 'test/salt/pillar/repo.sls'
-              state_top:
-                - '*':
-                    - epel
-                    - .
-            verifier:
-              inspec_tests:
-                - repo
+          3: {}
         inspec_suites_matrix:
           - default
           - repo
-          - amazonlinux
+          - ''
         platforms: *platforms_new
-        # Based on `*platforms_matrix_new_mainly_master_images`
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,            repo]
-          # - [ubuntu       ,   18.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,            repo]
-          # - [fedora       ,   31   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,            repo]
-          - [amazonlinux  ,    2   ,   master,      3,     amazonlinux]
-          # - [arch-base    ,  latest,   2019.2,      2,            repo]
+          - [debian       ,    0   ,   master,      0,              '']
+          - [ubuntu       ,    0   ,   master,      0,              '']
+          - [centos       ,    0   ,   master,      0,              '']
+          - [fedora       ,    0   ,   master,      0,              '']
+          - [opensuse/leap,    0   ,   master,      0,              '']
+          - [opensuse/tmbl,    0   ,   master,      0,              '']
+          - [amazonlinux  ,    0   ,   master,      0,              '']
+          - [oraclelinux  ,    0   ,   master,      0,              '']
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
       semrel_files:
         <<: *semrel_files_default
@@ -3023,15 +2782,19 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          # Not yet working with `20.04`
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          # # - [centos       ,    8   ,   master,      3,         default]
-          # Not yet working with `32`
-          - [fedora       ,   31   ,   master,      3,         default]
-          # - [opensuse/leap,   15.1 ,   master,      3,         default]
-          - [amazonlinux  ,    2   ,   master,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   18.04,   master,      0,         default]
+          - [ubuntu       ,   16.04,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          # # - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
         yamllint:
           ignore:
@@ -3078,13 +2841,22 @@ ssf:
         # simply because `centos-6` not working
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          - [opensuse/leap,   15.1 ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          - [arch-base    ,  latest,   2018.3,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   20.04,   master,      0,         default]
+          - [ubuntu       ,   18.04,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
+        yamllint:
+          ignore:
+            additional:
+              - nfs/osfamilymap.yaml
       semrel_files: *semrel_files_default
     nginx:
       context:
@@ -3103,16 +2875,7 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/default/pillar/nginx.sls'
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          # - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+        platforms_matrix: *platforms_matrix_without_gentoo_non_systemd
         travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files: *semrel_files_default
@@ -3133,13 +2896,16 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          # - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          - [ubuntu       ,   16.04,   2019.2,      3,         default]
-          - [centos       ,    7   ,   2019.2,      3,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          # # - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     node:
@@ -3180,52 +2946,23 @@ ssf:
           - source
           - repo
         platforms: *platforms_new
+        # Based on `*platforms_matrix_new`
         platforms_matrix:
-          # Based on `*platforms_matrix_new`
+          # NOTES:
+          # - `source` doesn't work anywhere at the moment
+          # - `repo` is only for Debian-based platforms
+          # - `archive` is the only suite working on `amazonlinux`
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
-          - [amazonlinux  ,    2   ,   3000.3,      3,         archive]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
-        # To deal with excessive instances when mimicking `kitchen list -b`
-        # If values are set, only use these as commented entries in the matrix
-        platforms_matrix_commented_includes:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [debian       ,   10   ,   master,      3,         archive]
-          - [debian       ,   10   ,   master,      3,          source]
-          - [debian       ,   10   ,   master,      3,            repo]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   31   ,   master,      3,         default]
-          - [opensuse/leap,   15.1 ,   master,      3,         default]
-          - [amazonlinux  ,    2   ,   master,      3,         default]
-          - [debian       ,   10   ,   3000.3,      3,         default]
-          - [debian       ,    9   ,   3000.3,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [centos       ,    8   ,   3000.3,      3,         default]
-          - [centos       ,    7   ,   3000.3,      3,         default]
-          - [fedora       ,   31   ,   3000.3,      3,         default]
-          - [opensuse/leap,   15.1 ,   3000.3,      3,         default]
-          - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      2,         default]
-          - [ubuntu       ,   16.04,   3000.3,      2,         default]
-          - [arch-base    ,  latest,   3000.3,      2,         default]
-          - [debian       ,   10   ,   2019.2,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [ubuntu       ,   16.04,   2019.2,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          - [centos       ,    7   ,   2019.2,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          - [opensuse/leap,   15.1 ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [centos       ,    6   ,   2019.2,      2,         default]
-          - [amazonlinux  ,    1   ,   2019.2,      2,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
+          - [debian       ,    0   ,   master,      0,            repo]
+          - [ubuntu       ,    0   ,   master,      0,            repo]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         archive]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         # Use this to start adopting the latest `platforms_matrix`
         use_tofs: true
         yamllint:
@@ -3249,6 +2986,9 @@ ssf:
               state_top:
                 - '*':
                     - .ng
+        # https://www.tecmint.com/install-ntp-in-rhel-8/
+        # - `ntp` package is no longer supported; use `chronyd` instead
+        platforms_matrix: *platforms_matrix_without_rhel8
         yamllint:
           rules:
             key-duplicates:
@@ -3268,7 +3008,7 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the nut formula is setup and configured correctly
-              supports: *supports_all_except_amazon
+              # supports: *supports_all_except_amazon
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/default.sls'
@@ -3276,32 +3016,31 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the nut services are not started in mode='none'
-              supports: *supports_all_except_amazon
+              # supports: *supports_all_except_amazon
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/mode-eq-none.sls'
+          2: {}
         inspec_suites_matrix:
           - default
           - mode-eq-none
+          - ''
         platforms: *platforms_new_inc_tiamat
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   tiamat,      3,         default]
-          # - [debian       ,    9   ,   tiamat,      3,         default]
-          - [ubuntu       ,   20.04,   tiamat,      3,         default]
-          # - [ubuntu       ,   18.04,   tiamat,      3,         default]
-          # # - [ubuntu       ,   16.04,   tiamat,      3,         default]
-          - [centos       ,    8   ,   tiamat,      3,         default]
-          # - [centos       ,    7   ,   tiamat,      3,         default]
-          - [centos       ,    7   ,   3001  ,      3,    mode-eq-none]
-          # # - [amazonlinux  ,    2   ,   tiamat,      3,         default]
-          # # - [oraclelinux  ,    8   ,   tiamat,      3,         default]
-          # # - [oraclelinux  ,    7   ,   tiamat,      3,         default]
-          # - [fedora       ,   32   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,    mode-eq-none]
-          - [fedora       ,   31   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,         default]
-          # # - [arch-base    ,  latest,   3000.3,      2,         default]
+          - [debian       ,    0   ,   master,      0,              '']
+          - [ubuntu       ,   20.04,   master,      0,              '']
+          - [ubuntu       ,   18.04,   master,      0,              '']
+          - [ubuntu       ,   16.04,   master,      0,    mode-eq-none]
+          - [centos       ,    0   ,   master,      0,              '']
+          - [fedora       ,    0   ,   master,      0,              '']
+          - [opensuse/leap,    0   ,   master,      0,              '']
+          - [opensuse/tmbl,    0   ,   master,      0,              '']
+          - [amazonlinux  ,    0   ,   master,      0,              '']
+          - [oraclelinux  ,    0   ,   master,      0,              '']
+          - [gentoo/stage3,  latest,   master,      3,    mode-eq-none]
+          - [gentoo/stage3, systemd,   master,      0,              '']
+          - [arch-base    ,    0   ,   3002.2,      0,              '']
         use_tofs: true
         yamllint:
           ignore:
@@ -3330,28 +3069,24 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
           # Unavailable for `centos-8`
           # https://bugs.centos.org/view.php?id=16959
-          # # - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
+          # `centos-7`: Docker/Systemd problem:
+          #   ... and PID file is not owned by root. Refusing.
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
           # TLS certificates error preventing the service from starting:
           #   Could not get the realpath: No such file or directory
-          # # - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          # Works but disabled since now have `20.04` and `18.04`
-          # - [ubuntu       ,   16.04,   2019.2,      3,         default]
-          # Docker/Systemd problem:
-          #   ... and PID file is not owned by root. Refusing.
-          # # - [centos       ,    7   ,   2019.2,      3,         default]
-          # - [fedora       ,   31   ,   2019.2,      3,         default]
-          # # - [centos       ,    6   ,   2019.2,      2,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
           # Not configured at all for `arch-base`
           # https://wiki.archlinux.org/index.php/OpenLDAP
-          # # - [arch-base    ,  latest,   2019.2,      2,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
       semrel_files: *semrel_files_default
     openntpd:
       context:
@@ -3379,17 +3114,16 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          # # - [centos       ,    8   ,   master,      3,         default]
-          # # - [fedora       ,   32   ,   master,      3,         default]
-          # # - [fedora       ,   31   ,   master,      3,         default]
-          # # - [opensuse/leap,   15.2 ,   master,      3,         default]
-          # # - [amazonlinux  ,    2   ,   master,      3,         default]
-          - [debian       ,    9   ,   3000.3,      3,         default]
-          - [ubuntu       ,   16.04,   3000.3,      2,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          # # - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
       semrel_files: *semrel_files_inc_map_jinja_verifier
     openssh:
       context:
@@ -3416,8 +3150,6 @@ ssf:
         map_jinja:
           verification:
             import: ['mapdata']
-        platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_new_mainly_master_images
         use_libsaltcli: true
         use_tofs: true
       semrel_files: *semrel_files_inc_map_jinja_verifier
@@ -3436,7 +3168,7 @@ ssf:
               depends: *depends_on_suite_share
               summary: >-
                 Verify that the openvpn formula is setup and configured correctly
-              supports: *supports_all_including_oracle_gentoo_and_windows
+              # supports: *supports_all_including_oracle_gentoo_and_windows
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/default.sls'
@@ -3451,23 +3183,20 @@ ssf:
         platforms: *platforms_new_saltimages
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [debian       ,    9   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          # # - [ubuntu       ,   16.04,   master,      3,         default]
-          # # - [centos       ,    8   ,   master,      3,         default]
-          - [centos       ,    7   ,   master,      3,         default]
-          # # - [fedora       ,   33   ,   master,      3,         default]
-          # # - [fedora       ,   32   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,         default]
-          - [opensuse/tmbl,  latest,   master,      3,         default]
-          - [amazonlinux  ,    2   ,   master,      3,         default]
-          # # - [oraclelinux  ,    8   ,   master,      3,         default]
-          # # - [gentoo/stage3,  latest,   master,      3,         default]
-          # # - [gentoo/stage3, systemd,   master,      3,         default]
-          - [oraclelinux  ,    7   ,   3002.2,      3,         default]
-          # # - [arch-base    ,  latest,   3002.2,      3,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   20.04,   master,      0,         default]
+          - [ubuntu       ,   18.04,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_libsaltcli: true
         yamllint:
           ignore:
@@ -3491,7 +3220,7 @@ ssf:
               depends: *depends_on_suite_share
               summary: >-
                 Verify that the packages formula is setup and configured correctly
-              supports: *supports_all_including_oracle
+              # supports: *supports_all_including_oracle
             provisioner:
               pillars_from_files: []
           1: *inspec_suites_kitchen__share_suite
@@ -3535,9 +3264,8 @@ ssf:
           5:
             includes:
               # Some of `*platforms_os_centos_new` + `oraclelinux-8`
-              - [centos       ,    8   ,   master,      3]
-              - [oraclelinux  ,    8   ,   master,      3]
-              - [centos       ,    8   ,   3000.3,      3]
+              - [centos       ,    8   ,      0  ,      0]
+              - [oraclelinux  ,    8   ,      0  ,      0]
             provisioner:
               dependencies: *dependencies_epel
               pillars_from_files:
@@ -3550,10 +3278,9 @@ ssf:
           6:
             includes:
               # Rest of `*platforms_os_centos_new`
-              - [centos       ,    7   ,   3000.3,      3]
-              - [centos       ,    8   ,   2019.2,      3]
-              - [centos       ,    7   ,   2019.2,      3]
-              - [centos       ,    6   ,   2019.2,      2]
+              - [centos       ,    7   ,      0  ,      0]
+              - [oraclelinux  ,    7   ,      0  ,      0]
+              - [centos       ,    6   ,      0  ,      0]
             provisioner:
               dependencies: *dependencies_epel
               pillars_from_files:
@@ -3592,6 +3319,15 @@ ssf:
                 - '*':
                     - .
             verifier: *verifier_inspec_tests_default
+          10:
+            includes: *platforms_gentoo
+            provisioner:
+              pillars_from_files:
+                - .sls: 'test/salt/pillar/gentoo.sls'
+              state_top:
+                - '*':
+                    - .
+            verifier: *verifier_inspec_tests_default
         inspec_suites_matrix:
           - default
           - debian
@@ -3602,60 +3338,26 @@ ssf:
           - amazon
           - suse
           - arch
-        platforms:
-          ### Temporary: `*platforms_new` with `oraclelinux-8` added
-          ### `master-py3`
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   20.04,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [centos       ,    8   ,   master,      3]
-          - [fedora       ,   32   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [opensuse/leap,   15.2 ,   master,      3]
-          - [amazonlinux  ,    2   ,   master,      3]
-          - [oraclelinux  ,    8   ,   master,      3]
-
-          ### `3000.3-py3`
-          - [debian       ,   10   ,   3000.3,      3]
-          - [debian       ,    9   ,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      3]
-          - [centos       ,    8   ,   3000.3,      3]
-          - [centos       ,    7   ,   3000.3,      3]
-          - [fedora       ,   31   ,   3000.3,      3]
-          - [opensuse/leap,   15.2 ,   3000.3,      3]
-          - [amazonlinux  ,    2   ,   3000.3,      3]
-          ### ` 3000.3-py2`
-          - [ubuntu       ,   18.04,   3000.3,      2]
-          - [ubuntu       ,   16.04,   3000.3,      2]
-          - [arch-base    ,  latest,   3000.3,      2]
-
-          ### `2019.2-py3`
-          - [debian       ,   10   ,   2019.2,      3]
-          - [debian       ,    9   ,   2019.2,      3]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          - [ubuntu       ,   16.04,   2019.2,      3]
-          - [centos       ,    8   ,   2019.2,      3]
-          - [centos       ,    7   ,   2019.2,      3]
-          - [fedora       ,   31   ,   2019.2,      3]
-          - [opensuse/leap,   15.2 ,   2019.2,      3]
-          - [amazonlinux  ,    2   ,   2019.2,      3]
-          ### `2019.2-py2`
-          - [centos       ,    6   ,   2019.2,      2]
-          - [amazonlinux  ,    1   ,   2019.2,      2]
-          - [arch-base    ,  latest,   2019.2,      2]
+          - gentoo
+        platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,          debian]
-          # # https://travis-ci.org/github/myii/packages-formula/jobs/693567191
-          # # - [ubuntu       ,   20.04,   master,      3,          ubuntu]
-          - [ubuntu       ,   18.04,   master,      3,          ubuntu]
-          - [centos       ,    8   ,   master,      3,         redhat8]
-          - [fedora       ,   32   ,   master,      3,          fedora]
-          - [oraclelinux  ,    8   ,   master,      3,         redhat8]
-          - [centos       ,    7   ,   3000.3,      3,          centos]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,            suse]
-          - [amazonlinux  ,    2   ,   3000.3,      3,          amazon]
-          - [arch-base    ,  latest,   2019.2,      2,            arch]
+          - [debian       ,    0   ,   master,      0,          debian]
+          # # - [ubuntu       ,    0   ,   master,      0,          ubuntu]
+          - [ubuntu       ,   18.04,   master,      0,          ubuntu]
+          # # - [centos       ,    0   ,   master,      0,         redhat8]
+          - [centos       ,    8   ,   master,      0,         redhat8]
+          - [centos       ,    7   ,   master,      0,          centos]
+          # # - [fedora       ,    0   ,   master,      0,          fedora]
+          - [fedora       ,   32   ,   master,      0,          fedora]
+          - [opensuse/leap,    0   ,   master,      0,            suse]
+          - [opensuse/tmbl,    0   ,   master,      0,            suse]
+          - [amazonlinux  ,    0   ,   master,      0,          amazon]
+          # # - [oraclelinux  ,    0   ,   master,      0,         redhat8]
+          - [oraclelinux  ,    8   ,   master,      0,         redhat8]
+          - [oraclelinux  ,    7   ,   master,      0,          centos]
+          - [gentoo/stage3,    0   ,   master,      0,          gentoo]
+          - [arch-base    ,    0   ,   3002.2,      0,            arch]
       semrel_files: *semrel_files_default
     php:
       context:
@@ -3738,13 +3440,19 @@ ssf:
         map_jinja:
           verification:
             import: ['php']
+        # Based on `*platforms_matrix_without_arch_and_gentoo`
         platforms_matrix:
-          - [debian       ,   10   ,   master,      3,       debian]
-          - [ubuntu       ,   18.04,   2019.2,      3,       ubuntu]
-          - [amazonlinux  ,    2   ,   2019.2,      3,       redhat]
-          - [fedora       ,   30   ,   2018.3,      3,       redhat]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,         suse]
-          # # - [centos       ,    6   ,   2017.7,      2,       redhat]
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,          debian]
+          - [ubuntu       ,    0   ,   master,      0,          ubuntu]
+          - [centos       ,    0   ,   master,      0,          redhat]
+          - [fedora       ,    0   ,   master,      0,          redhat]
+          - [opensuse/leap,    0   ,   master,      0,            suse]
+          - [opensuse/tmbl,    0   ,   master,      0,            suse]
+          - [amazonlinux  ,    0   ,   master,      0,          redhat]
+          - [oraclelinux  ,    0   ,   master,      0,          redhat]
+          # # - [gentoo/stage3,    0   ,   master,      0,          gentoo]
+          # # - [arch-base    ,    0   ,   3002.2,      0,            arch]
         use_tofs: true
       semrel_files: *semrel_files_inc_map_jinja_verifier
     postfix:
@@ -3768,8 +3476,6 @@ ssf:
                 - '*':
                     - .
                     - .config
-        platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_new
         yamllint:
           rules:
             key-duplicates:
@@ -3795,7 +3501,21 @@ ssf:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/postgres.sls'
         platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_new_mainly_master_images
+        # Based on `*platforms_matrix_without_gentoo`
+        platforms_matrix:
+          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,    0   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   20.04,   master,      0,         default]
+          - [ubuntu       ,   18.04,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
         yamllint:
           ignore:
@@ -3837,14 +3557,18 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          # - [centos       ,    8   ,   master,      3,         default]
-          # - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
-          # - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          # - [arch-base    ,  latest,   2019.2,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   16.04,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          - [fedora       ,   32   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         yamllint:
           ignore:
             additional:
@@ -3861,10 +3585,13 @@ ssf:
             repo: 'proftpd-formula'
         inspec_suites_kitchen:
           0:
-            includes: *platforms_osfamily_debian_new
+            # None of the platforms use `default` directly
+            includes: *includes_NONE
             inspec_yml:
               summary: >-
                 Verify that the proftpd formula is setup and configured correctly
+          1:
+            includes: *platforms_osfamily_debian_new
             provisioner:
               pillars:
                 - '*':
@@ -3874,11 +3601,8 @@ ssf:
                 - default.sls: 'test/salt/pillar/default.sls'
                 - .sls: 'test/salt/pillar/debian.sls'
             verifier: *verifier_inspec_tests_default
-          1:
+          2:
             includes: *platforms_osfamily_redhat_new_without_amazon
-            inspec_yml:
-              summary: >-
-                Verify that the proftpd formula is setup and configured correctly
             provisioner:
               pillars:
                 - '*':
@@ -3888,11 +3612,8 @@ ssf:
                 - default.sls: 'test/salt/pillar/default.sls'
                 - .sls: 'test/salt/pillar/redhat.sls'
             verifier: *verifier_inspec_tests_default
-          2:
+          3:
             includes: *platforms_osfamily_suse_new
-            inspec_yml:
-              summary: >-
-                Verify that the proftpd formula is setup and configured correctly
             provisioner:
               pillars:
                 - '*':
@@ -3902,11 +3623,8 @@ ssf:
                 - default.sls: 'test/salt/pillar/default.sls'
                 - .sls: 'test/salt/pillar/suse.sls'
             verifier: *verifier_inspec_tests_default
-          3:
+          4:
             includes: *platforms_os_amazonlinux_new
-            inspec_yml:
-              summary: >-
-                Verify that the proftpd formula is setup and configured correctly
             provisioner:
               dependencies: *dependencies_epel
               pillars:
@@ -3921,11 +3639,24 @@ ssf:
                     - epel
                     - .
             verifier: *verifier_inspec_tests_default
+          5:
+            includes: *platforms_gentoo
+            provisioner:
+              pillars:
+                - '*':
+                    - default
+                    - .
+              pillars_from_files:
+                - default.sls: 'test/salt/pillar/default.sls'
+                - .sls: 'test/salt/pillar/gentoo.sls'
+            verifier: *verifier_inspec_tests_default
         inspec_suites_matrix:
+          - default
           - debian
           - redhat
           - suse
           - amazonlinux
+          - gentoo
         kitchen:
           driver:
             run_options:
@@ -3934,15 +3665,22 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,          debian]
-          - [ubuntu       ,   20.04,   master,      3,          debian]
-          # - [ubuntu       ,   18.04,   master,      3,          debian]
-          - [centos       ,    8   ,   master,      3,          redhat]
-          - [fedora       ,   32   ,   master,      3,          redhat]
-          # - [fedora       ,   31   ,   master,      3,          redhat]
-          - [opensuse/leap,   15.2 ,   master,      3,            suse]
-          - [amazonlinux  ,    2   ,   master,      3,     amazonlinux]
-          # # - [arch-base    ,  latest,   2019.2,      2,         default]
+          - [debian       ,    0   ,   master,      0,          debian]
+          - [ubuntu       ,    0   ,   master,      0,          debian]
+          - [centos       ,    0   ,   master,      0,          redhat]
+          - [fedora       ,    0   ,   master,      0,          redhat]
+          - [opensuse/leap,    0   ,   master,      0,            suse]
+          - [opensuse/tmbl,    0   ,   master,      0,            suse]
+          - [amazonlinux  ,    0   ,   master,      0,     amazonlinux]
+          - [oraclelinux  ,    0   ,   master,      0,          redhat]
+          # Gentoo (OpenRC): Service `proftpd' needs non existent service `net'
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [gentoo/stage3, systemd,   master,      0,          gentoo]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
+        yamllint:
+          ignore:
+            additional:
+              - test/salt/pillar/redhat.sls
       semrel_files: *semrel_files_default
     prometheus:
       context:
@@ -3957,8 +3695,6 @@ ssf:
             repo: 'prometheus-formula'
         inspec_suites_kitchen:
           0:
-            excludes: &platforms_os_centos_6_2018_3
-              - [centos       ,    6   ,   2018.3,      2]
             inspec_yml:
               summary: >-
                 Verify that the prometheus formula is setup and configured correctly
@@ -3966,73 +3702,41 @@ ssf:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/default.sls'
           1:
-            excludes: *platforms_os_centos_6_2018_3
             inspec_yml:
               summary: >-
                 Verify that the prometheus formula is setup and configured correctly
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/repo.sls'
+          2: {}
         inspec_suites_matrix:
           - default
           - repo
+          - ''
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [debian       ,   10   ,   3000.3,      3,            repo]
-          - [debian       ,    9   ,   3000.3,      3,         default]
-          # - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [centos       ,    7   ,   3000.3,      3,            repo]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
-          - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          # - [fedora       ,   31   ,   2019.2,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
-        # To deal with excessive instances when mimicking `kitchen list -b`
-        # If values are set, only use these as commented entries in the matrix
-        platforms_matrix_commented_includes:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [fedora       ,   31   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,         default]
-          - [amazonlinux  ,    2   ,   master,      3,         default]
-          - [debian       ,   10   ,   3000.3,      3,         default]
-          - [debian       ,    9   ,   3000.3,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [centos       ,    8   ,   3000.3,      3,         default]
-          - [centos       ,    7   ,   3000.3,      3,         default]
-          - [fedora       ,   31   ,   3000.3,      3,         default]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
-          - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      2,         default]
-          - [ubuntu       ,   16.04,   3000.3,      2,         default]
-          - [arch-base    ,  latest,   3000.3,      2,         default]
-          - [debian       ,   10   ,   2019.2,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [ubuntu       ,   16.04,   2019.2,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          - [centos       ,    7   ,   2019.2,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          - [opensuse/leap,   15.2 ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [centos       ,    6   ,   2019.2,      2,         default]
-          - [amazonlinux  ,    1   ,   2019.2,      2,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
-          - [debian       ,   10   ,   3000.3,      3,            repo]
-          - [centos       ,    7   ,   3000.3,      3,            repo]
+          - [debian       ,    0   ,   master,      0,              '']
+          - [ubuntu       ,   20.04,   master,      0,              '']
+          - [ubuntu       ,   18.04,   master,      0,              '']
+          - [ubuntu       ,   16.04,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,              '']
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,              '']
+          # TODO: Fix since `centos-8` works
+          # - [oraclelinux  ,    8   ,   master,      0,         default]
+          # - [oraclelinux  ,    7   ,   master,      0,              '']
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
         yamllint:
           ignore:
             additional:
               - prometheus/osfamilymap.yaml
+              - test/salt/pillar/repo.sls
       semrel_files: *semrel_files_default
     rabbitmq:
       context:
@@ -4073,12 +3777,21 @@ ssf:
             import: ['pkgs']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,          latest]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          # # - [debian       ,    9   ,   2018.3,      2,         default]
-          # # - [ubuntu       ,   16.04,   2017.7,      2,         default]
+          # # - [debian       ,    0   ,   master,      0,         default]
+          - [debian       ,   10   ,   master,      0,          latest]
+          - [debian       ,    9   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          - [fedora       ,   33   ,   master,      0,          latest]
+          - [fedora       ,   32   ,   master,      0,         default]
+          # # - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
       semrel_files: *semrel_files_inc_map_jinja_verifier
     redis:
       context:
@@ -4095,16 +3808,7 @@ ssf:
                 - '*':
                     - .common
                     - .server
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          # - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          # - [arch-base    ,  latest,   2019.2,      2,         default]
-          # # - [debian       ,    9   ,   2018.3,      2,         default]
-          # # - [ubuntu       ,   16.04,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
+        platforms_matrix: *platforms_matrix_without_arch_and_gentoo
       semrel_files: *semrel_files_default
     rkhunter:
       context:
@@ -4145,12 +3849,16 @@ ssf:
           - suse
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,          debian]
-          - [ubuntu       ,   18.04,   2019.2,      3,          debian]
-          - [centos       ,    8   ,   2019.2,      3,          redhat]
-          - [fedora       ,   30   ,   2018.3,      3,          redhat]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,            suse]
-          # # - [centos       ,    6   ,   2017.7,      2,          redhat]
+          - [debian       ,    0   ,   master,      0,          debian]
+          - [ubuntu       ,    0   ,   master,      0,          debian]
+          - [centos       ,    0   ,   master,      0,          redhat]
+          - [fedora       ,    0   ,   master,      0,          redhat]
+          - [opensuse/leap,    0   ,   master,      0,            suse]
+          - [opensuse/tmbl,    0   ,   master,      0,            suse]
+          - [amazonlinux  ,    0   ,   master,      0,          redhat]
+          - [oraclelinux  ,    0   ,   master,      0,          redhat]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files: *semrel_files_default
@@ -4177,26 +3885,10 @@ ssf:
           #           - ._mapdata
           #           - .
           1: *inspec_suites_kitchen__share_suite
-        platforms: *platforms_new_inc_tiamat
+        # platforms: *platforms_new_inc_tiamat
         # If `opensuse/leap` fixed, then can use this instead
         # platforms_matrix: *platforms_matrix_new_inc_tiamat
-        platforms_matrix:
-          # Based on `*platforms_matrix_new_inc_tiamat`
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   tiamat,      3,         default]
-          # - [debian       ,    9   ,   tiamat,      3,         default]
-          - [ubuntu       ,   20.04,   tiamat,      3,         default]
-          # - [ubuntu       ,   18.04,   tiamat,      3,         default]
-          # - [ubuntu       ,   16.04,   tiamat,      3,         default]
-          - [centos       ,    8   ,   tiamat,      3,         default]
-          # - [centos       ,    7   ,   tiamat,      3,         default]
-          - [amazonlinux  ,    2   ,   tiamat,      3,         default]
-          # # - [oraclelinux  ,    8   ,   tiamat,      3,         default]
-          # # - [oraclelinux  ,    7   ,   tiamat,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          # - [fedora       ,   31   ,   master,      3,         default]
-          # # - [opensuse/leap,   15.2 ,   master,      3,         default]
-          - [arch-base    ,  latest,   3000.3,      2,         default]
+        # platforms_matrix:
         use_tofs: true
       semrel_files:
         <<: *semrel_files_default
@@ -4215,21 +3907,21 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the Rspamd repositories are configured correctly
-              supports: *supports_debian_ubuntu_centos_arch
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          # # - [ubuntu       ,   18.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          # # - [fedora       ,   32   ,   master,      3,         default]
-          # # - [fedora       ,   31   ,   master,      3,         default]
-          # # - [opensuse/leap,   15.2 ,   master,      3,         default]
-          # # - [amazonlinux  ,    2   ,   master,      3,         default]
-          - [centos       ,    7   ,   3000.3,      3,         default]
-          - [arch-base    ,  latest,   3000.3,      2,         default]
-          # # - [centos       ,    6   ,   2019.2,      2,         default]
+          # # - [debian       ,    0   ,   master,      0,         default]
+          - [debian       ,   10   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   20.04,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          # # - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         yamllint:
           ignore:
             additional:
@@ -4261,29 +3953,15 @@ ssf:
           0: *inspec_suites_kitchen__share_suite
           1:
             includes:
-              # [os           ,  os_ver, salt_ver, py_ver]
-              - [debian       ,   10   ,   3002.2,      3]
-              - [debian       ,    9   ,   3002.2,      3]
-              - [ubuntu       ,   20.04,   3002.2,      3]
-              - [ubuntu       ,   18.04,   3002.2,      3]
-              - [ubuntu       ,   16.04,   3002.2,      3]
-              - [centos       ,    8   ,   3002.2,      3]
-              - [centos       ,    7   ,   3002.2,      3]
-              - [fedora       ,   33   ,   3002.2,      3]
-              - [fedora       ,   32   ,   3002.2,      3]
-              - [opensuse/leap,   15.2 ,   3002.2,      3]
-              - [opensuse/tmbl,  latest,   3002.2,      3]
-              - [amazonlinux  ,    2   ,   3002.2,      3]
-              - [oraclelinux  ,    8   ,   3002.2,      3]
-              - [oraclelinux  ,    7   ,   3002.2,      3]
+              # # TODO:
               # # - [arch-base    ,  latest,   3002.2,      3]
-              - [gentoo/stage3,  latest,   3002.2,      3]
-              - [gentoo/stage3, systemd,   3002.2,      3]
+              # [os           ,  os_ver, salt_ver, py_ver]
+              - [0            ,    0   ,   3002.2,      3]
             inspec_yml:
               depends: *depends_on_suite_share
               summary: >-
                 Verify that Salt `v3002-py3` is setup and configured
-              supports: *supports_all_including_oracle_and_gentoo
+              # supports: *supports_all_including_oracle_and_gentoo
             provisioner:
               pillars:
                 - '*':
@@ -4295,29 +3973,15 @@ ssf:
               state_top: *state_top_salt
           2:
             includes:
-              # [os           ,  os_ver, salt_ver, py_ver]
-              - [debian       ,   10   ,   3001.4,      3]
-              - [debian       ,    9   ,   3001.4,      3]
-              - [ubuntu       ,   20.04,   3001.4,      3]
-              - [ubuntu       ,   18.04,   3001.4,      3]
-              - [ubuntu       ,   16.04,   3001.4,      3]
-              - [centos       ,    8   ,   3001.4,      3]
-              - [centos       ,    7   ,   3001.4,      3]
-              - [fedora       ,   33   ,   3001.4,      3]
-              - [fedora       ,   32   ,   3001.4,      3]
-              - [opensuse/leap,   15.2 ,   3001.4,      3]
-              - [opensuse/tmbl,  latest,   3001.4,      3]
-              - [amazonlinux  ,    2   ,   3001.4,      3]
-              - [oraclelinux  ,    8   ,   3001.4,      3]
-              - [oraclelinux  ,    7   ,   3001.4,      3]
+              # # TODO:
               # # - [arch-base    ,  latest,   3001.4,      3]
-              - [gentoo/stage3,  latest,   3001.4,      3]
-              - [gentoo/stage3, systemd,   3001.4,      3]
+              # [os           ,  os_ver, salt_ver, py_ver]
+              - [0            ,    0   ,   3001.4,      3]
             inspec_yml:
               depends: *depends_on_suite_share
               summary: >-
                 Verify that Salt `v3001-py3` is setup and configured
-              supports: *supports_all_including_oracle_and_gentoo
+              # supports: *supports_all_including_oracle_and_gentoo
             provisioner:
               pillars:
                 - '*':
@@ -4330,23 +3994,12 @@ ssf:
           3:
             includes:
               # [os           ,  os_ver, salt_ver, py_ver]
-              - [debian       ,   10   ,   3000.6,      3]
-              - [debian       ,    9   ,   3000.6,      3]
-              - [ubuntu       ,   18.04,   3000.6,      3]
-              - [ubuntu       ,   16.04,   3000.6,      3]
-              - [centos       ,    8   ,   3000.6,      3]
-              - [centos       ,    7   ,   3000.6,      3]
-              - [opensuse/leap,   15.2 ,   3000.6,      3]
-              - [amazonlinux  ,    2   ,   3000.6,      3]
-              - [oraclelinux  ,    8   ,   3000.6,      3]
-              - [oraclelinux  ,    7   ,   3000.6,      3]
-              - [gentoo/stage3,  latest,   3000.6,      3]
-              - [gentoo/stage3, systemd,   3000.6,      3]
+              - [0            ,    0   ,   3000.6,      3]
             inspec_yml:
               depends: *depends_on_suite_share
               summary: >-
                 Verify that Salt `v3000-py3` is setup and configured
-              supports: *supports_all_including_oracle_gentoo_and_windows
+              # supports: *supports_all_including_oracle_gentoo_and_windows
             provisioner:
               pillars:
                 - '*':
@@ -4358,15 +4011,15 @@ ssf:
               state_top: *state_top_salt
           4:
             includes:
-              # [os           ,  os_ver, salt_ver, py_ver]
-              - [ubuntu       ,   18.04,   3000.6,      2]
-              - [ubuntu       ,   16.04,   3000.6,      2]
+              # # TODO:
               # # - [arch-base    ,  latest,   3000.6,      2]
+              # [os           ,  os_ver, salt_ver, py_ver]
+              - [0            ,    0   ,   3000.6,      2]
             inspec_yml:
               depends: *depends_on_suite_share
               summary: >-
                 Verify that Salt `v3000-py2` is setup and configured
-              supports: *supports_all_including_oracle_and_gentoo
+              # supports: *supports_all_including_oracle_and_gentoo
             provisioner:
               pillars:
                 - '*':
@@ -4625,7 +4278,11 @@ ssf:
               summary: >-
                 Verify that the strongswan formula is setup and configured correctly
         platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_new
+        # Gentoo failure:
+        #   !!! Multiple package instances within a single package slot have been pulled
+        #   !!! into the dependency graph, resulting in a slot conflict:
+        #   dev-libs/openssl:0
+        platforms_matrix: *platforms_matrix_without_gentoo
         use_tofs: true
       semrel_files: *semrel_files_default
     stunnel:
@@ -4638,7 +4295,6 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the stunnel formula is setup and configured correctly
-              supports: *supports_debian_ubuntu
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/stunnel.sls'
@@ -4646,15 +4302,7 @@ ssf:
                 - '*':
                     - .pillar_certs
                     - .
-        platforms_matrix:
-          # Couldn't use `*platforms_matrix_osfamily_debian` because it is
-          # currently failing on both `ubuntu-16.04` and `debian-8`
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          # # - [debian       ,    9   ,   2018.3,      2,         default]
+        platforms_matrix: *platforms_matrix_osfamily_debian
       semrel_files: *semrel_files_default
     sudoers:
       context:
@@ -4684,8 +4332,6 @@ ssf:
         map_jinja:
           verification:
             import: ['sudoers']
-        platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_new_mainly_master_images
       semrel_files: *semrel_files_inc_map_jinja_verifier
     suricata:
       context:
@@ -4701,38 +4347,24 @@ ssf:
             inspec_yml:
               summary: >-
                 Verify that the suricata formula is setup and configured correctly
-              supports: *supports_debian_ubuntu_centos
+              # supports: *supports_debian_ubuntu_centos
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/default.sls'
-        platforms:
-          # Effectively from `*platforms_new`
-          # Based on `saltimages` at the time of this comment
-          # [os           ,  os_ver, salt_ver, py_ver]
-          - [ubuntu       ,   20.04,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [centos       ,    8   ,   master,      3]
-          - [ubuntu       ,   20.04,   3001  ,      3]
-          - [ubuntu       ,   18.04,   3001  ,      3]
-          - [centos       ,    8   ,   3001  ,      3]
-          - [centos       ,    7   ,   3001  ,      3]
-          - [ubuntu       ,   18.04,   3000.3,      3]
-          - [centos       ,    8   ,   3000.3,      3]
-          - [centos       ,    7   ,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      2]
-          - [ubuntu       ,   16.04,   3000.3,      2]
-          - [ubuntu       ,   18.04,   2019.2,      3]
-          - [ubuntu       ,   16.04,   2019.2,      3]
-          - [centos       ,    8   ,   2019.2,      3]
-          - [centos       ,    7   ,   2019.2,      3]
-          # # - [centos       ,    6   ,   2019.2,      2]
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [centos       ,    8   ,   3001  ,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [ubuntu       ,   16.04,   3000.3,      2,         default]
-          # # - [centos       ,    7   ,   2019.2,      3,         default]
+          # # - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    8   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          # # - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    8   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         yamllint:
           ignore:
             additional:
@@ -4757,15 +4389,6 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/sysctl.sls'
-        platforms_matrix:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,         default]
-          - [arch-base    ,  latest,   2017.7,      2,         default]
       semrel_files: *semrel_files_default
     syslog-ng:
       context:
@@ -4780,8 +4403,11 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/syslog_ng.sls'
-        travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
+        yamllint:
+          ignore:
+            additional:
+              - syslog_ng/osfamilymap.yaml
       semrel_files:
         <<: *semrel_files_default
         formula/libtofs.jinja:
@@ -4831,20 +4457,17 @@ ssf:
         platforms: *platforms_new_inc_tiamat
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   tiamat,      3,         default]
-          # - [debian       ,    9   ,   tiamat,      3,         default]
-          - [ubuntu       ,   20.04,   tiamat,      3,         default]
-          # - [ubuntu       ,   18.04,   tiamat,      3,         default]
-          # - [ubuntu       ,   16.04,   tiamat,      3,         default]
-          # # - [centos       ,    8   ,   tiamat,      3,         default]
-          - [centos       ,    7   ,   tiamat,      3,         default]
-          - [amazonlinux  ,    2   ,   tiamat,      3,         default]
-          # # - [oraclelinux  ,    8   ,   tiamat,      3,         default]
-          # # - [oraclelinux  ,    7   ,   tiamat,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          # - [fedora       ,   31   ,   master,      3,         default]
-          # # - [opensuse/leap,   15.2 ,   master,      3,         default]
-          - [arch-base    ,  latest,   3000.3,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          # # - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     telegraf:
@@ -4862,13 +4485,17 @@ ssf:
                 - .sls: 'test/salt/pillar/telegraf.sls'
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   31   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [centos       ,    7   ,   2019.2,      2,         default]
-          # # - [debian       ,    9   ,   2018.3,      2,         default]
-          # # - [ubuntu       ,   16.04,   2018.3,      2,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
+          - [fedora       ,   32   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     template:
@@ -4887,7 +4514,7 @@ ssf:
               depends: *depends_on_suite_share
               summary: >-
                 Verify that the TEMPLATE formula is setup and configured correctly
-              supports: *supports_all_including_oracle_and_gentoo
+              # supports: *supports_all_including_oracle_and_gentoo
             provisioner:
               pillars:
                 - '*':
@@ -4902,21 +4529,6 @@ ssf:
                     - TEMPLATE
           1: *inspec_suites_kitchen__share_suite
           2:
-            includes: *platforms_os_upstart
-            provisioner:
-              pillars:
-                - '*':
-                    - TEMPLATE
-                    - define_roles
-              pillars_from_files:
-                - TEMPLATE.sls: 'test/salt/pillar/upstart.sls'
-                - define_roles.sls: 'test/salt/pillar/define_roles.sls'
-              state_top:
-                - '*':
-                    - ._mapdata
-                    - TEMPLATE
-            verifier: *verifier_inspec_tests_default
-          3:
             includes: *platforms_gentoo
             provisioner:
               pillars:
@@ -4935,92 +4547,22 @@ ssf:
             verifier: *verifier_inspec_tests_default
         inspec_suites_matrix:
           - default
-          - upstart
           - gentoo
         map_jinja:
           verification:
             import: ['TEMPLATE']
-        platforms:
-          ### `tiamat-py3`
-          - [debian       ,   10   ,   tiamat,      3]
-          - [debian       ,    9   ,   tiamat,      3]
-          - [ubuntu       ,   20.04,   tiamat,      3]
-          - [ubuntu       ,   18.04,   tiamat,      3]
-          - [ubuntu       ,   16.04,   tiamat,      3]
-          - [centos       ,    8   ,   tiamat,      3]
-          - [centos       ,    7   ,   tiamat,      3]
-          - [amazonlinux  ,    2   ,   tiamat,      3]
-          - [oraclelinux  ,    8   ,   tiamat,      3]
-          - [oraclelinux  ,    7   ,   tiamat,      3]
-
-          ### `master-py3`
-          - [debian       ,   10   ,   master,      3]
-          - [ubuntu       ,   20.04,   master,      3]
-          - [ubuntu       ,   18.04,   master,      3]
-          - [centos       ,    8   ,   master,      3]
-          - [fedora       ,   32   ,   master,      3]
-          - [fedora       ,   31   ,   master,      3]
-          - [opensuse/leap,   15.2 ,   master,      3]
-          - [amazonlinux  ,    2   ,   master,      3]
-          # - [oraclelinux  ,    8   ,   master,      3]
-          - [gentoo/stage3,  latest,   master,      3]
-          - [gentoo/stage3, systemd,   master,      3]
-
-          ### `3001-py3`
-          - [debian       ,   10   ,   3001  ,      3]
-          - [debian       ,    9   ,   3001  ,      3]
-          - [ubuntu       ,   20.04,   3001  ,      3]
-          - [ubuntu       ,   18.04,   3001  ,      3]
-          - [centos       ,    8   ,   3001  ,      3]
-          - [centos       ,    7   ,   3001  ,      3]
-          - [fedora       ,   32   ,   3001  ,      3]
-          - [fedora       ,   31   ,   3001  ,      3]
-          - [opensuse/leap,   15.2 ,   3001  ,      3]
-          - [amazonlinux  ,    2   ,   3001  ,      3]
-          - [oraclelinux  ,    8   ,   3001  ,      3]
-          - [oraclelinux  ,    7   ,   3001  ,      3]
-          - [gentoo/stage3,  latest,   3001  ,      3]
-          - [gentoo/stage3, systemd,   3001  ,      3]
-
-          ### `3000.3-py3`
-          - [debian       ,   10   ,   3000.3,      3]
-          - [debian       ,    9   ,   3000.3,      3]
-          - [ubuntu       ,   18.04,   3000.3,      3]
-          - [centos       ,    8   ,   3000.3,      3]
-          - [centos       ,    7   ,   3000.3,      3]
-          - [fedora       ,   31   ,   3000.3,      3]
-          - [opensuse/leap,   15.2 ,   3000.3,      3]
-          - [amazonlinux  ,    2   ,   3000.3,      3]
-          - [gentoo/stage3,  latest,   3000.3,      3]
-          - [gentoo/stage3, systemd,   3000.3,      3]
-          ### ` 3000.3-py2`
-          - [ubuntu       ,   18.04,   3000.3,      2]
-          - [ubuntu       ,   16.04,   3000.3,      2]
-          - [arch-base    ,  latest,   3000.3,      2]
-
-          ### `2019.2-py2`
-          - [centos       ,    6   ,   2019.2,      2]
-          - [amazonlinux  ,    1   ,   2019.2,      2]
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   tiamat,      3,         default]
-          # - [debian       ,    9   ,   tiamat,      3,         default]
-          - [ubuntu       ,   20.04,   tiamat,      3,         default]
-          # - [ubuntu       ,   18.04,   tiamat,      3,         default]
-          # - [ubuntu       ,   16.04,   tiamat,      3,         default]
-          - [centos       ,    8   ,   tiamat,      3,         default]
-          # - [centos       ,    7   ,   tiamat,      3,         default]
-          - [amazonlinux  ,    2   ,   tiamat,      3,         default]
-          - [oraclelinux  ,    8   ,   tiamat,      3,         default]
-          # - [oraclelinux  ,    7   ,   tiamat,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          # - [fedora       ,   31   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   master,      3,         default]
-          - [gentoo/stage3,  latest,   master,      3,          gentoo]
-          - [gentoo/stage3, systemd,   master,      3,          gentoo]
-          - [arch-base    ,  latest,   3000.3,      2,         default]
-          # # - [centos       ,    6   ,   2019.2,      2,         upstart]
-          - [amazonlinux  ,    1   ,   2019.2,      2,         upstart]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [gentoo/stage3,    0   ,   master,      0,          gentoo]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_libsaltcli: true
         use_tofs: true
       semrel_files:
@@ -5060,8 +4602,6 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/timezone.sls'
-        platforms: *platforms_new
-        platforms_matrix: *platforms_matrix_new
       semrel_files: *semrel_files_default
     tomcat:
       context:
@@ -5095,25 +4635,7 @@ ssf:
           verification:
             import: ['tomcat']
         platforms: *platforms_new
-        platforms_matrix:
-          # Similar to `*platforms_matrix_without_arch_new` which will be
-          # introduced shortly with the `logrotate` fixes
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          # Tomcat not available for CentOS 8 yet (like it is for CentOS 7)
-          # https://pkgs.org/search/?q=tomcat
-          # # - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,         default]
-          - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          - [debian       ,    9   ,   3000.3,      3,         default]
-          - [centos       ,    7   ,   2019.2,      3,         default]
-          # Tomcat appears to require an older version of JVM on Arch
-          # yamllint disable-line rule:line-length
-          #   jsvc.exec error: Cannot find any VM in Java Home /usr/lib/jvm/default-runtime
-          #   jsvc.exec error: Cannot locate JVM library file
-          # # - [arch-base    ,  latest,   2019.2,      2,         default]
+        platforms_matrix: *platforms_matrix_without_rhel8_and_gentoo
         rubocop:
           AllCops:
             Exclude:
@@ -5121,7 +4643,7 @@ ssf:
           Cops:
             Lint/EmptyWhen:
               Exclude:
-                - 'test/integration/default/controls/config_spec.rb'
+                - 'test/integration/default/controls/config.rb'
         yamllint:
           ignore:
             additional:
@@ -5134,9 +4656,10 @@ ssf:
             repo: 'ufw-formula'
         inspec_suites_kitchen:
           0:
-            includes: &platforms_working_with_ufw_default_suite
-              - [debian       ,   10   ,   master,      3]
-              - [centos       ,    8   ,   master,      3]
+            includes:
+              - [debian       ,   10   ,      0  ,      0]
+              - [centos       ,    8   ,      0  ,      0]
+              - [oraclelinux  ,    8   ,      0  ,      0]
             inspec_yml:
               summary: >-
                 Verify that the ufw formula is setup and configured correctly
@@ -5144,7 +4667,6 @@ ssf:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/default.sls'
           1:
-            excludes: *platforms_working_with_ufw_default_suite
             inspec_yml:
               summary: >-
                 Verify that the ufw formula is setup and configured correctly
@@ -5164,14 +4686,22 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,    without-ipv6]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,    without-ipv6]
-          # - [ubuntu       ,   18.04,   3000.3,      3,    without-ipv6]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,    without-ipv6]
-          - [amazonlinux  ,    2   ,   3000.3,      3,    without-ipv6]
-          - [arch-base    ,  latest,   2019.2,      2,    without-ipv6]
+          # # - [debian       ,    0   ,   master,      0,    without-ipv6]
+          - [debian       ,   10   ,   master,      0,         default]
+          - [debian       ,    9   ,   master,      0,    without-ipv6]
+          - [ubuntu       ,    0   ,   master,      0,    without-ipv6]
+          # # - [centos       ,    0   ,   master,      0,    without-ipv6]
+          - [centos       ,    8   ,   master,      0,         default]
+          - [centos       ,    7   ,   master,      0,    without-ipv6]
+          - [fedora       ,    0   ,   master,      0,    without-ipv6]
+          - [opensuse/leap,    0   ,   master,      0,    without-ipv6]
+          # # - [opensuse/tmbl,    0   ,   master,      0,    without-ipv6]
+          - [amazonlinux  ,    0   ,   master,      0,    without-ipv6]
+          # # - [oraclelinux  ,    0   ,   master,      0,    without-ipv6]
+          - [oraclelinux  ,    8   ,   master,      0,         default]
+          - [oraclelinux  ,    7   ,   master,      0,    without-ipv6]
+          - [gentoo/stage3,    0   ,   master,      0,    without-ipv6]
+          - [arch-base    ,    0   ,   3002.2,      0,    without-ipv6]
         use_tofs: true
       semrel_files: *semrel_files_default
     users:
@@ -5214,48 +4744,19 @@ ssf:
         inspec_suites_matrix:
           - default
           - vimrc
+        # Based on `*platforms_matrix_without_arch_and_gentoo`
         platforms_matrix:
-          # Based on `*platforms_matrix_without_arch`
-          - [debian       ,   10   ,   master,      3,           vimrc]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [opensuse/leap,   15.1 ,   2019.2,      3,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          # - [arch-base    ,  latest,   2018.3,      2,         default]
-          # # - [centos       ,    6   ,   2017.7,      2,         default]
-        # To deal with excessive instances when mimicking `kitchen list -b`
-        # If values are set, only use these as commented entries in the matrix
-        platforms_matrix_commented_includes:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          - [fedora       ,   31   ,   master,      3,         default]
-          - [opensuse/leap,   15.1 ,   master,      3,         default]
-          - [amazonlinux  ,    2   ,   master,      3,         default]
-          - [debian       ,   10   ,   2019.2,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          - [ubuntu       ,   18.04,   2019.2,      3,         default]
-          - [centos       ,    8   ,   2019.2,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          - [opensuse/leap,   15.1 ,   2019.2,      3,         default]
-          - [centos       ,    7   ,   2019.2,      2,         default]
-          - [amazonlinux  ,    2   ,   2019.2,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
-          - [fedora       ,   30   ,   2018.3,      3,         default]
-          - [debian       ,    9   ,   2018.3,      2,         default]
-          - [ubuntu       ,   16.04,   2018.3,      2,         default]
-          - [centos       ,    7   ,   2018.3,      2,         default]
-          - [opensuse/leap,   15.1 ,   2018.3,      2,         default]
-          - [amazonlinux  ,    1   ,   2018.3,      2,         default]
-          - [arch-base    ,  latest,   2018.3,      2,         default]
-          - [debian       ,    8   ,   2017.7,      2,         default]
-          - [ubuntu       ,   16.04,   2017.7,      2,         default]
-          - [centos       ,    6   ,   2017.7,      2,         default]
-          - [fedora       ,   30   ,   2017.7,      2,         default]
-          - [opensuse/leap,   15.1 ,   2017.7,      2,         default]
-          - [amazonlinux  ,    1   ,   2017.7,      2,         default]
-          - [arch-base    ,  latest,   2017.7,      2,         default]
+          - [debian       ,    0   ,   master,      0,           vimrc]
+          - [ubuntu       ,    0   ,   master,      0,           vimrc]
+          - [centos       ,    0   ,   master,      0,           vimrc]
+          - [fedora       ,    0   ,   master,      0,           vimrc]
+          - [opensuse/leap,    0   ,   master,      0,           vimrc]
+          - [opensuse/tmbl,    0   ,   master,      0,           vimrc]
+          - [amazonlinux  ,    0   ,   master,      0,           vimrc]
+          - [oraclelinux  ,    0   ,   master,      0,           vimrc]
+          # # - [gentoo/stage3,    0   ,   master,      0,           vimrc]
+          # # - [arch-base    ,    0   ,   3002.2,      0,           vimrc]
       semrel_files: *semrel_files_default
     varnish:
       context:
@@ -5299,13 +4800,20 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          # # - [debian       ,   10   ,   master,      3,         default]
-          - [centos       ,    8   ,   master,      3,         default]
-          # # - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,            suse]
-          # # - [amazonlinux  ,    2   ,   3000.3,      3,         default]
-          - [fedora       ,   31   ,   2019.2,      3,         default]
-          - [arch-base    ,  latest,   2019.2,      2,         default]
+          # # - [debian       ,    0   ,   master,      0,         default]
+          - [debian       ,   10   ,   master,      0,         default]
+          # # - [ubuntu       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,   20.04,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       ,    8   ,   master,      0,         default]
+          - [fedora       ,    0   ,   master,      0,         default]
+          - [opensuse/leap,    0   ,   master,      0,         default]
+          - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [oraclelinux  ,    8   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   3002.2,      0,         default]
         # TODO: Upgrade to latest TOFS in a subsequent PR, since a legacy version
         # is active for the time being (needs to be checked for regressions)
         use_tofs: legacy
@@ -5355,47 +4863,19 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,              '']
-          - [ubuntu       ,   20.04,   master,      3,     prod_server]
-          - [centos       ,    8   ,   master,      3,     prod_server]
-          - [fedora       ,   32   ,   master,      3,     prod_server]
-          - [opensuse/leap,   15.2 ,   3000.3,      3,     prod_server]
-          - [amazonlinux  ,    2   ,   3000.3,      3,     prod_server]
-          # # - [arch-base    ,  latest,   2019.2,      2,     prod_server]
-        # To deal with excessive instances when mimicking `kitchen list -b`
-        # If values are set, only use these as commented entries in the matrix
-        platforms_matrix_commented_includes:
-          # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          # - [debian       ,   10   ,   master,      3,     prod_server]
-          - [ubuntu       ,   18.04,   master,      3,     prod_server]
-          - [centos       ,    8   ,   master,      3,     prod_server]
-          - [fedora       ,   31   ,   master,      3,     prod_server]
-          - [opensuse/leap,   15.1 ,   master,      3,     prod_server]
-          - [amazonlinux  ,    2   ,   master,      3,     prod_server]
-          - [debian       ,   10   ,   3000.3,      3,     prod_server]
-          - [debian       ,    9   ,   3000.3,      3,     prod_server]
-          - [ubuntu       ,   18.04,   3000.3,      3,     prod_server]
-          - [centos       ,    8   ,   3000.3,      3,     prod_server]
-          - [centos       ,    7   ,   3000.3,      3,     prod_server]
-          - [fedora       ,   31   ,   3000.3,      3,     prod_server]
-          - [opensuse/leap,   15.1 ,   3000.3,      3,     prod_server]
-          - [amazonlinux  ,    2   ,   3000.3,      3,     prod_server]
-          - [ubuntu       ,   18.04,   3000.3,      2,     prod_server]
-          - [ubuntu       ,   16.04,   3000.3,      2,     prod_server]
-          - [arch-base    ,  latest,   3000.3,      2,     prod_server]
-          - [debian       ,   10   ,   2019.2,      3,     prod_server]
-          - [debian       ,    9   ,   2019.2,      3,     prod_server]
-          - [ubuntu       ,   18.04,   2019.2,      3,     prod_server]
-          - [ubuntu       ,   16.04,   2019.2,      3,     prod_server]
-          - [centos       ,    8   ,   2019.2,      3,     prod_server]
-          - [centos       ,    7   ,   2019.2,      3,     prod_server]
-          - [fedora       ,   31   ,   2019.2,      3,     prod_server]
-          - [opensuse/leap,   15.1 ,   2019.2,      3,     prod_server]
-          - [amazonlinux  ,    2   ,   2019.2,      3,     prod_server]
-          - [centos       ,    6   ,   2019.2,      2,     prod_server]
-          - [amazonlinux  ,    1   ,   2019.2,      2,     prod_server]
-          - [arch-base    ,  latest,   2019.2,      2,     prod_server]
-        travis: *travis_do_not_use_single_job_for_linters
+          - [debian       ,    0   ,   master,      0,              '']
+          # # - [ubuntu       ,    0   ,   master,      0,              '']
+          - [ubuntu       ,   20.04,   master,      0,              '']
+          - [ubuntu       ,   18.04,   master,      0,              '']
+          - [centos       ,    0   ,   master,      0,              '']
+          # # - [fedora       ,    0   ,   master,      0,              '']
+          - [fedora       ,   32   ,   master,      0,              '']
+          - [opensuse/leap,    0   ,   master,      0,              '']
+          - [opensuse/tmbl,    0   ,   master,      0,              '']
+          - [amazonlinux  ,    0   ,   master,      0,              '']
+          - [oraclelinux  ,    0   ,   master,      0,              '']
+          # # - [gentoo/stage3,    0   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   3002.2,      0,              '']
       semrel_files: *semrel_files_default
     vim:
       context:
@@ -5410,7 +4890,6 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/vim.sls'
-        platforms_matrix: *platforms_matrix_without_arch
       semrel_files: *semrel_files_default
     vsftpd:
       context:
@@ -5425,6 +4904,8 @@ ssf:
             provisioner:
               pillars_from_files:
                 - .sls: 'test/salt/pillar/vsftpd.sls'
+        # Gentoo (OpenRC): Service `vsftpd' needs non existent service `net'
+        platforms_matrix: *platforms_matrix_without_gentoo_non_systemd
       semrel_files: *semrel_files_default
     zabbix:
       context:
@@ -5456,15 +4937,17 @@ ssf:
         platforms: *platforms_new
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,         default]
-          - [ubuntu       ,   20.04,   master,      3,         default]
-          - [fedora       ,   32   ,   master,      3,         default]
-          - [ubuntu       ,   18.04,   3000.3,      3,         default]
-          - [fedora       ,   31   ,   3000.3,      3,         default]
-          - [debian       ,    9   ,   2019.2,      3,         default]
-          # Avoiding, since becoming temperamental with `service.restart` timeouts:
-          # https://travis-ci.org/github/myii/zabbix-formula/jobs/692305786#L3914-L3919
-          # # - [ubuntu       ,   16.04,   2019.2,      3,         default]
+          - [debian       ,    0   ,   master,      0,         default]
+          - [ubuntu       ,    0   ,   master,      0,         default]
+          # # - [centos       ,    0   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]  # 33: v5
+          - [fedora       ,   32   ,   master,      0,         default]
+          # # - [opensuse/leap,    0   ,   master,      0,         default]
+          # # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   3002.2,      0,         default]
         use_tofs: true
         yamllint:
           rules:

--- a/ssf/libcimatrix.jinja
+++ b/ssf/libcimatrix.jinja
@@ -15,22 +15,88 @@
 {%-   filter indent(width) %}
 {#-     Centralise duplication from here and `kitchen.yml` #}
 {%-     set platform_and_suite_names_done = [] %}
-{%-     for platform in platforms %}
+{%-     set commented_platform_done = [] %}
+{%-     for platform in saltimages %}
 {%-       set os       = platform[0] %}
 {%-       set os_ver   = platform[1] %}
 {%-       set salt_ver = platform[2] %}
 {%-       set py_ver   = platform[3] %}
+
+{#-       Check if the platform matches any of the `platforms` listed #}
+{%-       set ns_check_platform = namespace(match=False) %}
+{%-       for check in platforms %}
+{%-         set ch_os       = check[0] if check[0] else platform[0] %}
+{%-         set ch_os_ver   = check[1] if check[1] else platform[1] %}
+{%-         set ch_salt_ver = check[2] if check[2] else platform[2] %}
+{%-         set ch_py_ver   = check[3] if check[3] else platform[3] %}
+{%-         if platform == [ch_os, ch_os_ver, ch_salt_ver, ch_py_ver] %}
+{%-           set ns_check_platform.match = True %}
+{%-           break %}
+{%-         endif %}
+{%-       endfor %}
+{#-       If a match hasn't been found, go to the next entry under `saltimages` #}
+{%-       if not ns_check_platform.match %}
+{%-         continue %}
+{%-       endif %}
+
 {#-       Work through each inspec suite defined for the formula, ordered by the suite number #}
 {%-       for index in range(0, inspec_suites_kitchen | length) %}
 {%-         set suite = inspec_suites_kitchen[index] %}
 {#-         Only continue if the `suite.name` is present in the given matrix #}
 {%-         if suite.name in inspec_suites_matrix %}
 {%-           set suite_name = suite.name %}
-{%-           set includes = suite.includes %}
-{%-           set excludes = suite.excludes %}
+
+{#-           TODO: Use `for` loop (0..1) to merge these two blocks into one #}
+{#-                 As in, don't need separate `includes` and `excludes` blocks #}
+{#-           set includes = suite.includes #}
+{%-           set includes = [] %}
+{%-           if suite.includes %}
+{%-             if suite.includes == [[]] %}
+{%-               set includes = suite.includes %}
+{%-             else %}
+{#-               Centralise duplication from here and `libcimatrix.jinja` #}
+{%-               for clude_platform in saltimages %}
+{#-                 Check if the clude_platform matches any of the `platforms` listed #}
+{%-                 for check in suite.includes %}
+{%-                   set ch_os       = check[0] if check[0] else clude_platform[0] %}
+{%-                   set ch_os_ver   = check[1] if check[1] else clude_platform[1] %}
+{%-                   set ch_salt_ver = check[2] if check[2] else clude_platform[2] %}
+{%-                   set ch_py_ver   = check[3] if check[3] else clude_platform[3] %}
+{%-                   if clude_platform == [ch_os, ch_os_ver, ch_salt_ver, ch_py_ver] %}
+{%-                     do includes.append(clude_platform) %}
+{%-                     break %}
+{%-                   endif %}
+{%-                 endfor %}
+{%-               endfor %}
+{%-             endif %}
+{%-           endif %}
+
+{#-           set excludes = suite.excludes #}
+{%-           set excludes = [] %}
+{%-           if suite.excludes %}
+{%-             if suite.excludes == [[]] %}
+{%-               set excludes = suite.excludes %}
+{%-             else %}
+{#-               Centralise duplication from here and `libcimatrix.jinja` #}
+{%-               for clude_platform in saltimages %}
+{#-                 Check if the clude_platform matches any of the `platforms` listed #}
+{%-                 for check in suite.excludes %}
+{%-                   set ch_os       = check[0] if check[0] else clude_platform[0] %}
+{%-                   set ch_os_ver   = check[1] if check[1] else clude_platform[1] %}
+{%-                   set ch_salt_ver = check[2] if check[2] else clude_platform[2] %}
+{%-                   set ch_py_ver   = check[3] if check[3] else clude_platform[3] %}
+{%-                   if clude_platform == [ch_os, ch_os_ver, ch_salt_ver, ch_py_ver] %}
+{%-                     do excludes.append(clude_platform) %}
+{%-                     break %}
+{%-                   endif %}
+{%-                 endfor %}
+{%-               endfor %}
+{%-             endif %}
+{%-           endif %}
+
 {%-           set platform_and_suite_name = platform + [suite_name] %}
-{#-         Prevent using a `platform_and_suite_name` more than once #}
-{#-         I.e. In case suite_name resolves to `''` multiple times #}
+{#-           Prevent using a `platform_and_suite_name` more than once #}
+{#-           I.e. In case suite_name resolves to `''` multiple times #}
 {%-           if platform_and_suite_name not in platform_and_suite_names_done %}
 {%-             do platform_and_suite_names_done.append(platform_and_suite_name) %}
 {#-             Only continue depending on an appropriate combination of `includes` and `excludes`: #}
@@ -50,12 +116,42 @@
 {%-             if (platform in includes) or (not includes and platform not in excludes) %}
 {%-               set include_instance = True %}
 {#-               Compare combined [platform] and [suite_name] to see if enabled in the matrix #}
-{%-               if platform_and_suite_name in platforms_matrix %}
+
+{%-               set platforms_matrix_expanded = [] %}
+{%-               if platforms_matrix and platforms_matrix != [[]] %}
+{#-                 Centralise duplication from here and `libcimatrix.jinja` #}
+{%-                 for matrix_platform in saltimages %}
+{#-                   Check if the matrix_platform matches any of the `platforms` listed #}
+{%-                   for check in platforms_matrix %}
+{%-                     set ch_os       = check[0] if check[0] else matrix_platform[0] %}
+{%-                     set ch_os_ver   = check[1] if check[1] else matrix_platform[1] %}
+{%-                     set ch_salt_ver = check[2] if check[2] else matrix_platform[2] %}
+{%-                     set ch_py_ver   = check[3] if check[3] else matrix_platform[3] %}
+{%-                     set ch_suite    = check[4] %}
+{%-                     if matrix_platform == [ch_os, ch_os_ver, ch_salt_ver, ch_py_ver] %}
+{%-                       do platforms_matrix_expanded.append(matrix_platform + [ch_suite]) %}
+{#-                       We want to break in all conditions except the following: #}
+{#-                       1. The `java-formula` should only have extra lines for `ubuntu` #}
+{%-                       if not (semrel_formula in ['java'] and ch_os in ['ubuntu']) %}
+{%-                         break %}
+{%-                       endif %}
+{%-                     endif %}
+{%-                   endfor %}
+{%-                 endfor %}
+{%-               endif %}
+
+{%-               if platform_and_suite_name in platforms_matrix_expanded %}
 {%-                 set comment = '' %}
 {%-               else %}
 {%-                 set comment = '# ' %}
-{%-                 if platforms_matrix_commented_includes and platform_and_suite_name not in platforms_matrix_commented_includes %}
-{%-                   set include_instance = False %}
+{#-                 Only include commented instances from the main platforms #}
+{#-                 Otherwise only use the first suite for the other platforms #}
+{%-                 if not (salt_ver == 'master' or [os, salt_ver] == ['arch-base', 3002.2]) %}
+{%-                   if platform not in commented_platform_done %}
+{%-                     do commented_platform_done.append(platform) %}
+{%-                   else %}
+{%-                     set include_instance = False %}
+{%-                   endif %}
 {%-                 endif %}
 {%-               endif %}
 {#-               Define `instance_and_env`, modified for new Travis format or GitLab format #}
@@ -87,14 +183,19 @@
                       salt_ver | replace('.', '-'),
                       py_ver,
                     ) %}
-{%-                 if semrel_formula == 'apache'
-                    and [suite_name, os, os_ver, salt_ver] == ['default', 'amazonlinux', 2, 'master'] %}
+{%-                 if semrel_formula == 'apache' and
+                       [suite_name, os, os_ver, salt_ver] == ['default', 'amazonlinux', 2, 'master']
+%}
 # https://community.letsencrypt.org/t/localhost-crt-does-not-exist-or-is-empty/103979
 {%-                 endif %}
 {{ comment }}{{ list_format }}{{ instance_and_env }}{{ instance }}{{ test_template }}
+{#-               [End] if include_instance #}
 {%-               endif %}
+{#-             [End] if (platform in includes) or (not includes and platform not in excludes) #}
 {%-             endif %}
+{#-           [End] if platform_and_suite_name not in platform_and_suite_names_done #}
 {%-           endif %}
+{#-         [End] if suite.name in inspec_suites_matrix #}
 {%-         endif %}
 {#-       [End] for index in range(0, inspec_suites_kitchen | length) #}
 {%-       endfor %}


### PR DESCRIPTION
Establish all of the following changes:

* Use wildcards for (but *maintain* current ordering of entries when rendered):
  - NOTE: Use new values to ensure reverse compatibility,
          where need to be able to use the original, non-wildcard method instead
  - To filter out `platforms` that must not be included (and `platform_matrix`)
  - `platform_suite` inclusions and exclusions
  - `platforms_matrix` (after initial testing)
* Use latest pre-salted images
  - Active unique combination of platforms for all formulas:
    + E.g. `apt-formula` must only have Debian-based platforms in the list
    + Based around idea of supplying these in the `FORMULA` file
    + Active became the wildcards that have been implemented
* Move `dependencies` to the top in each suite (where used)
* Use new solution to replace `platforms_matrix_commented_includes`:
  - Use wildcards?
  - Automatic generation from "ideal, unique platforms"?

When running global tests across new pre-salted images:

* `vim-interestingwords` is exceptionally useful here, with the following words:
  - `platforms` (use wildcards to ensure all relevant platforms are selected)
  - `supports` (pretty much want to comment all of these out, so InSpec tests run)
  - `include` & `exclude` (similar to `platforms`)
