### PR TITLE
feat(gemfile+lock): use `ssf` customised `kitchen-docker` repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ source 'https://rubygems.org'
 gem 'inspec',      '~> 4.22.22'
 # Install the `kitchen-docker` gem from GitHub because the latest version
 # currently available (`2.10.0`) doesn't include a recent fix for Gentoo.
-gem 'kitchen-docker', github: 'test-kitchen/kitchen-docker', ref: '41e80fe'
+# rubocop:disable Layout/LineLength
+gem 'kitchen-docker', git: 'https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker', branch: 'ssf'
+# rubocop:enable Layout/LineLength
 gem 'kitchen-inspec', '>= 2.2.1'
 gem 'kitchen-salt', '>= 0.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/test-kitchen/kitchen-docker.git
-  revision: 41e80fed3a7cc86323e19c16a5a340cebf7e5848
-  ref: 41e80fe
+  remote: https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker
+  revision: 042e6921940a28d2502258b6a5ff3be17dd2fd37
+  branch: ssf
   specs:
     kitchen-docker (2.10.0)
       test-kitchen (>= 1.0.0)

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -62,8 +62,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore: standardise structure ('`'.gitignore'`' & '`'_mapdata.rb'`') [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/292'
+            title: "ci(gemfile+lock): use '`'ssf'`' customised '`'kitchen-docker'`' repo [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/294'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/Gemfile
+++ b/ssf/files/default/Gemfile
@@ -7,6 +7,8 @@ source 'https://rubygems.org'
 gem 'inspec',      '~> 4.22.22'
 # Install the `kitchen-docker` gem from GitHub because the latest version
 # currently available (`2.10.0`) doesn't include a recent fix for Gentoo.
-gem 'kitchen-docker', github: 'test-kitchen/kitchen-docker', ref: '41e80fe'
+# rubocop:disable Layout/LineLength
+gem 'kitchen-docker', git: 'https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker', branch: 'ssf'
+# rubocop:enable Layout/LineLength
 gem 'kitchen-inspec', '>= 2.2.1'
 gem 'kitchen-salt', '>= 0.6.3'

--- a/ssf/files/default/Gemfile.lock
+++ b/ssf/files/default/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/test-kitchen/kitchen-docker.git
-  revision: 41e80fed3a7cc86323e19c16a5a340cebf7e5848
-  ref: 41e80fe
+  remote: https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker
+  revision: 042e6921940a28d2502258b6a5ff3be17dd2fd37
+  branch: ssf
   specs:
     kitchen-docker (2.10.0)
       test-kitchen (>= 1.0.0)

--- a/ssf/files/tofs_openssh-formula/Gemfile
+++ b/ssf/files/tofs_openssh-formula/Gemfile
@@ -7,7 +7,9 @@ source 'https://rubygems.org'
 gem 'inspec',      '~> 4.22.22'
 # Install the `kitchen-docker` gem from GitHub because the latest version
 # currently available (`2.10.0`) doesn't include a recent fix for Gentoo.
-gem 'kitchen-docker', github: 'test-kitchen/kitchen-docker', ref: '41e80fe'
+# rubocop:disable Layout/LineLength
+gem 'kitchen-docker', git: 'https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker', branch: 'ssf'
+# rubocop:enable Layout/LineLength
 gem 'kitchen-inspec', '>= 2.2.1'
 gem 'kitchen-salt', '>= 0.6.3'
 

--- a/ssf/files/tofs_openssh-formula/Gemfile.lock
+++ b/ssf/files/tofs_openssh-formula/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/test-kitchen/kitchen-docker.git
-  revision: 41e80fed3a7cc86323e19c16a5a340cebf7e5848
-  ref: 41e80fe
+  remote: https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker
+  revision: 042e6921940a28d2502258b6a5ff3be17dd2fd37
+  branch: ssf
   specs:
     kitchen-docker (2.10.0)
       test-kitchen (>= 1.0.0)

--- a/ssf/files/tofs_openvpn-formula/Gemfile
+++ b/ssf/files/tofs_openvpn-formula/Gemfile
@@ -7,7 +7,9 @@ source 'https://rubygems.org'
 gem 'inspec',      '~> 4.22.22'
 # Install the `kitchen-docker` gem from GitHub because the latest version
 # currently available (`2.10.0`) doesn't include a recent fix for Gentoo.
-gem 'kitchen-docker', github: 'test-kitchen/kitchen-docker', ref: '41e80fe'
+# rubocop:disable Layout/LineLength
+gem 'kitchen-docker', git: 'https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker', branch: 'ssf'
+# rubocop:enable Layout/LineLength
 gem 'kitchen-inspec', '>= 2.2.1'
 gem 'kitchen-salt', '>= 0.6.3'
 gem 'rspec-retry'

--- a/ssf/files/tofs_openvpn-formula/Gemfile.lock
+++ b/ssf/files/tofs_openvpn-formula/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/test-kitchen/kitchen-docker.git
-  revision: 41e80fed3a7cc86323e19c16a5a340cebf7e5848
-  ref: 41e80fe
+  remote: https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker
+  revision: 042e6921940a28d2502258b6a5ff3be17dd2fd37
+  branch: ssf
   specs:
     kitchen-docker (2.10.0)
       test-kitchen (>= 1.0.0)


### PR DESCRIPTION
Idea was prompted by an unnecessary failure on Tumbleweed during the
`kitchen create` phase.

https://gitlab.com/myii/fail2ban-formula/-/jobs/1033337903

```console
( 8/10) Installing: openssh-server-8.4p1-4.1.x86_64 [...error]
Installation of openssh-server-8.4p1-4.1.x86_64 failed:
Error: Subprocess failed. Error: RPM failed: find: '/etc/init.d/rc[35].d': No such file or directory
ERROR: neither useradd nor busybox found!
error: %prein(openssh-server-8.4p1-4.1.x86_64) scriptlet failed, exit status 1
error: openssh-server-8.4p1-4.1.x86_64: install failed
error: openssh-server-8.4p1-3.1.x86_64: erase skipped
Abort, retry, ignore? [a/r/i] (a): a
Warning: %posttrans scripts skipped while aborting:
    sudo-1.9.5p2-1.2.x86_64.rpm
    openssh-server-8.4p1-4.1.x86_64.rpm
Problem occurred during or after installation or removal of packages:
Installation has been aborted as directed.
Please see the above error message for a hint.
```

Conducted various local tests but hitting the same failure.  Even
noticed it occurring in the `salt-bootstrap` CI.

The idea is that there is no need to reinstall packages that are already
present in our pre-salted images.  This approach will also improve
performance as well.  Tested out this idea on a few repos and Tumbleweed
is working fine.