### PR TITLE
feat(kitchen): allow specifying InSpec `controls`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -126,6 +126,7 @@ ssf_node_anchors:
                 - '*':
                     - .
             verifier:
+              controls: []
               inspec_tests_path_prefix: 'test/integration'
               inspec_tests:
                 - .

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -332,6 +332,16 @@ suites:
         {%- endfor %}
       {%- endif %}
     verifier:
+      {%- set controls = suite.verifier.controls %}
+      {%- if controls %}
+      controls:
+        {%- for control in controls %}
+        {%-   if control.startswith('.') %}
+        {%-     set control = semrel_formula ~ control %}
+        {%-   endif %}
+        - {{ control }}
+        {%- endfor %}
+      {%- endif %}
       inspec_tests:
         {%- set inspec_tests_path_prefix = suite.verifier.inspec_tests_path_prefix %}
         {%- for test_suite in suite.verifier.inspec_tests %}


### PR DESCRIPTION
Pretty straightforward change, hopefully.

Comments?

Configuration of:
```
   firefox:
        inspec_suites_kitchen:
          0:
            inspec_yml:
              summary: >-
                Verify that the firefox formula is setup and configured correctly
              supports:
                - windows
            provisioner:
              state_top:
                - '*':
                    - .
            verifier:
              controls:
                - .package.install
                - .gpo.install
                - .gpo.config
```
would produce:
```
suites:
  - name: default
    provisioner:
      state_top:
        base:
          '*':
            - firefox
      pillars:
        top.sls:
          base:
            '*':
              - firefox
      pillars_from_files:
        firefox.sls: pillar.example
    verifier:
      inspec_tests:
        - path: test/integration/default
      controls:
        - firefox.package.install
        - firefox.gpo.install
        - firefox.gpo.config
 ```