### PR TITLE
feat(kitchen): remove Fedora legacy `crypto-policies` workaround

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(kitchen+gitlab): adjust matrix to add '`'3003'`' [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/318'
+            title: "ci(kitchen): remove Fedora legacy '`'crypto-policies'`' workaround [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/319'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -149,20 +149,6 @@ image: {{ 'saltimages' if [os, os_ver, salt_ver, py_ver] in saltimages else 'net
 {%-         do prov_cmds.append('- pacman --noconfirm -Syu glibc') %}
 {%-       endif %}
 {%-     endif %}
-{#-     Specific to newer versions of Fedora (from `33`) across some of the formulas #}
-{#-     These instances install `crypto-policies-scripts` during the `kitchen converge`, #}
-{#-     which then results in the `kitchen verify` hitting the SSH authentication error #}
-{%-     if os == 'fedora' %}
-{%-       if [semrel_formula, os_ver] in [
-            ['libvirt', 33],
-            ['libvirt', 34],
-            ['sysstat', 34],
-          ] %}
-{%-         do prov_cmds.append('- dnf -y update') %}
-{%-         do prov_cmds.append('- dnf install -y crypto-policies-scripts') %}
-{%-         do prov_cmds.append('- update-crypto-policies --set LEGACY') %}
-{%-       endif %}
-{%-     endif %}
 {#-     Prepare the commands if available#}
 {%-     if prov_cmds %}
 provision_command:


### PR DESCRIPTION
The workaround has been added to the pre-salted images now:

* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/93