### PR TITLE
feat(arch): use `master` as default instance for Arch Linux

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -367,6 +367,7 @@ ssf:
     - [amazonlinux  ,    2   ,   master,      3]  # amaz-02.0-master-py3
     - [oraclelinux  ,    8   ,   master,      3]  # orac-08.0-master-py3
     - [oraclelinux  ,    7   ,   master,      3]  # orac-07.0-master-py3
+    - [arch-base    ,  latest,   master,      3]  # arch-late-master-py3
     - [gentoo/stage3,  latest,   master,      3]  # gent-late-master-py3
     - [gentoo/stage3, systemd,   master,      3]  # gent-sysd-master-py3
 

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(gitlab-ci): update Fedora testing after '`'3003'`' release [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/322'
+            title: "ci: add '`'arch-master'`' to matrix and update '`'.travis.yml'`' [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/323'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'
@@ -151,16 +151,18 @@ ssf_node_anchors:
           - [0            ,    0   ,      0  ,      0]
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,    0   ,   master,      0,         default]
-          - [ubuntu       ,    0   ,   master,      0,         default]
-          - [centos       ,    0   ,   master,      0,         default]
-          - [fedora       ,    0   ,   master,      0,         default]
-          - [opensuse/leap,    0   ,   master,      0,         default]
-          - [opensuse/tmbl,    0   ,   master,      0,         default]
-          - [amazonlinux  ,    0   ,   master,      0,         default]
-          - [oraclelinux  ,    0   ,   master,      0,         default]
-          - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
+          - [0            ,    0   ,   master,      0,         default]
+          # Keeping this below to make it easier to work with `formulas.yaml`
+          # - [debian       ,    0   ,   master,      0,         default]
+          # - [ubuntu       ,    0   ,   master,      0,         default]
+          # - [centos       ,    0   ,   master,      0,         default]
+          # - [fedora       ,    0   ,   master,      0,         default]
+          # - [opensuse/leap,    0   ,   master,      0,         default]
+          # - [opensuse/tmbl,    0   ,   master,      0,         default]
+          # - [amazonlinux  ,    0   ,   master,      0,         default]
+          # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # - [arch-base    ,    0   ,   master,      0,         default]
+          # - [gentoo/stage3,    0   ,   master,      0,         default]
         # To deal with excessive instances when mimicking `kitchen list -b`
         # If values are set, only use these as commented entries in the matrix
         platforms_matrix_commented_includes: []

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -137,8 +137,8 @@ ssf_node_anchors:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         # yamllint disable-line rule:line-length
         platforms_matrix_without_arch_and_tumbleweed: &platforms_matrix_without_arch_and_tumbleweed
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
@@ -150,8 +150,8 @@ ssf_node_anchors:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         platforms_matrix_without_gentoo: &platforms_matrix_without_gentoo
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [debian       ,    0   ,   master,      0,         default]
@@ -162,8 +162,8 @@ ssf_node_anchors:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         # yamllint disable-line rule:line-length
         platforms_matrix_without_gentoo_non_systemd: &platforms_matrix_without_gentoo_non_systemd
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
@@ -175,8 +175,8 @@ ssf_node_anchors:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3, systemd,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         # yamllint disable-line rule:line-length
         platforms_matrix_without_centos_and_oracle: &platforms_matrix_without_centos_and_oracle
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
@@ -188,8 +188,8 @@ ssf_node_anchors:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         platforms_matrix_without_rhel8: &platforms_matrix_without_rhel8
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [debian       ,    0   ,   master,      0,         default]
@@ -202,8 +202,8 @@ ssf_node_anchors:
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         # yamllint disable-line rule:line-length
         platforms_matrix_without_rhel8_and_gentoo: &platforms_matrix_without_rhel8_and_gentoo
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
@@ -217,8 +217,8 @@ ssf_node_anchors:
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         platforms_matrix_jetbrains: &platforms_matrix_jetbrains
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [debian       ,    0   ,   master,      0,         default]
@@ -232,8 +232,8 @@ ssf_node_anchors:
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,            arch]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,            arch]
         # yamllint disable-line rule:line-length
         travis_do_not_use_single_job_for_linters: &travis_do_not_use_single_job_for_linters
           use_single_job_for_linters: false
@@ -422,8 +422,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]  # POSSIBLE
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,              '']  # modules
+          - [arch-base    ,    0   ,   master,      0,         modules]  # POSSIBLE
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         modules]  # POSSIBLE
           - [freebsd      ,    0   ,   master,      3,              '']
         testing_freebsd:
           active: true
@@ -707,8 +707,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,      0  ,      0]
           - [amazonlinux  ,    0   ,      0  ,      0]
           - [oraclelinux  ,    0   ,      0  ,      0]
-          # # - [gentoo/stage3,    0   ,      0  ,      0]
           # # - [arch-base    ,    0   ,      0  ,      0]
+          # # - [gentoo/stage3,    0   ,      0  ,      0]
         platforms_matrix:
           # - failed api-amazonlinux-2-master-py3
           # - failed api-centos-7-master-py3
@@ -769,8 +769,8 @@ ssf:
           # TODO: Submit PR to enable `oraclelinux-7`
           # - [oraclelinux  ,    7   ,   master,      0,           shell]
           # - [oraclelinux  ,    7   ,   master,      0,       keepstore]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
         yamllint:
           ignore:
@@ -818,8 +818,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         travis: *travis_do_not_use_single_job_for_linters
         yamllint:
           rules:
@@ -898,8 +898,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
       semrel_files: *semrel_files_default
     consul:
       context:
@@ -976,8 +976,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     devstack:
@@ -1047,8 +1047,8 @@ ssf:
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
       semrel_files: *semrel_files_inc_map_jinja_verifier
     django:
       context:
@@ -1080,8 +1080,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
       semrel_files: *semrel_files_default
     docker:
       context:
@@ -1139,10 +1139,10 @@ ssf:
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         archive]
           - [oraclelinux  ,    0   ,   master,      0,           clean]
+          - [arch-base    ,    0   ,   master,      0,              '']
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
           - [gentoo/stage3, systemd,   master,      0,         archive]
           - [gentoo/stage3, systemd,   master,      0,           clean]
-          - [arch-base    ,    0   ,   3003.0,      0,              '']
         use_tofs: true
         yamllint:
           ignore:
@@ -1294,8 +1294,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
       semrel_files: *semrel_files_inc_map_jinja_verifier
     golang:
       context:
@@ -1339,8 +1339,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,              '']
           - [amazonlinux  ,    0   ,   master,      0,              '']
           - [oraclelinux  ,    0   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   master,      0,              '']
           # # - [gentoo/stage3,    0   ,   master,      0,              '']
-          - [arch-base    ,    0   ,   3003.0,      0,              '']
           - [freebsd      ,    0   ,   master,      3,              '']
           - [openbsd      ,    0   ,   3001.1,      3,         package]
           - [windows      ,    0   ,   latest,      3,              '']
@@ -1465,8 +1465,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_github_actions: true
         yamllint:
           ignore:
@@ -1542,8 +1542,8 @@ ssf:
           - [amazonlinux  ,    0   ,   master,      0,              '']
           - [oraclelinux  ,    8   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   master,      0,              '']
           - [gentoo/stage3,    0   ,   master,      0,              '']
-          - [arch-base    ,    0   ,   3003.0,      0,              '']
         yamllint:
           rules:
             key-duplicates:
@@ -2043,8 +2043,8 @@ ssf:
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,            arch]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,            arch]
         use_tofs: true
         yamllint:
           ignore:
@@ -2583,8 +2583,8 @@ ssf:
           # # Should work but failing dependency resolution
           # # - [oraclelinux  ,    0   ,   master,      0,             rpm]
           - [oraclelinux  ,    8   ,   master,      0,             rpm]
+          - [arch-base    ,    0   ,   master,      0,             git]
           - [gentoo/stage3,    0   ,   master,      0,             git]
-          - [arch-base    ,    0   ,   3003.0,      0,             git]
       semrel_files: *semrel_files_default
     libvirt:
       context:
@@ -2635,8 +2635,8 @@ ssf:
           # Can be enabled soon once InSpec packages check is fixed
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_libsaltcli: true
         use_tofs: true
       semrel_files: *semrel_files_default
@@ -2686,8 +2686,8 @@ ssf:
           # - https://gitlab.com/myii/locale-formula/-/jobs/1039987126
           # - https://gitlab.com/myii/locale-formula/-/jobs/1040056073
           # # - [oraclelinux  ,    7   ,   master,      0,          redhat]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
       semrel_files: *semrel_files_default
     logrotate:
       context:
@@ -2803,8 +2803,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,              '']
           - [amazonlinux  ,    0   ,   master,      0,              '']
           - [oraclelinux  ,    0   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     maven:
@@ -2890,8 +2890,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
         yamllint:
           ignore:
@@ -2952,8 +2952,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         yamllint:
           ignore:
             additional:
@@ -3027,8 +3027,8 @@ ssf:
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    8   ,   master,      0,              '']
           - [oraclelinux  ,    7   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3, systemd,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
           - [freebsd      ,    0   ,   master,      3,         default]
         testing_freebsd:
           active: true
@@ -3065,8 +3065,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     node:
@@ -3123,8 +3123,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         archive]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         # Use this to start adopting the latest `platforms_matrix`
         use_tofs: true
         yamllint:
@@ -3205,9 +3205,9 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,              '']
           - [amazonlinux  ,    0   ,   master,      0,              '']
           - [oraclelinux  ,    0   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   master,      0,              '']
           - [gentoo/stage3,  latest,   master,      3,    mode-eq-none]
           - [gentoo/stage3, systemd,   master,      0,              '']
-          - [arch-base    ,    0   ,   3003.0,      0,              '']
         use_tofs: true
         yamllint:
           ignore:
@@ -3252,10 +3252,10 @@ ssf:
           #   Could not get the realpath: No such file or directory
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
-          # # - [gentoo/stage3,    0   ,   master,      0,         default]
           # Not configured at all for `arch-base`
           # https://wiki.archlinux.org/index.php/OpenLDAP
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
+          # # - [gentoo/stage3,    0   ,   master,      0,         default]
       semrel_files: *semrel_files_default
     openntpd:
       context:
@@ -3287,8 +3287,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
       semrel_files: *semrel_files_inc_map_jinja_verifier
     openssh:
       context:
@@ -3324,8 +3324,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
           - [freebsd      ,    0   ,   master,      3,         default]
           - [openbsd      ,    0   ,   3001.1,      3,         default]
         testing_freebsd:
@@ -3377,8 +3377,8 @@ ssf:
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
           # # TODO: Fix 2 failing states in order to enable this
           # # - [freebsd      ,    0   ,   master,      3,         default]
           - [windows      ,    0   ,   latest,      3,         default]
@@ -3568,8 +3568,8 @@ ssf:
           # # - [oraclelinux  ,    0   ,   master,      0,         redhat8]
           - [oraclelinux  ,    8   ,   master,      0,         redhat8]
           - [oraclelinux  ,    7   ,   master,      0,          centos]
+          - [arch-base    ,    0   ,   master,      0,            arch]
           - [gentoo/stage3,    0   ,   master,      0,          gentoo]
-          - [arch-base    ,    0   ,   3003.0,      0,            arch]
           - [windows      ,    0   ,   latest,      3,         windows]
         testing_windows:
           active: true
@@ -3670,8 +3670,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,            suse]
           - [amazonlinux  ,    0   ,   master,      0,          redhat]
           - [oraclelinux  ,    0   ,   master,      0,          redhat]
+          # # - [arch-base    ,    0   ,   master,      0,            arch]
           # # - [gentoo/stage3,    0   ,   master,      0,          gentoo]
-          # # - [arch-base    ,    0   ,   3003.0,      0,            arch]
           - [freebsd      ,    0   ,   master,      3,         freebsd]
         testing_freebsd:
           active: true
@@ -3742,8 +3742,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
           - [freebsd      ,    0   ,   master,      3,         default]
           # # - [openbsd      ,    0   ,   3001.1,      3,         default]
           # # - [windows      ,    0   ,   latest,      3,         default]
@@ -3803,8 +3803,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         yamllint:
           ignore:
             additional:
@@ -3912,10 +3912,10 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,            suse]
           - [amazonlinux  ,    0   ,   master,      0,     amazonlinux]
           - [oraclelinux  ,    0   ,   master,      0,          redhat]
+          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
           # Gentoo (OpenRC): Service `proftpd' needs non existent service `net'
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
           - [gentoo/stage3, systemd,   master,      0,          gentoo]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         yamllint:
           ignore:
             additional:
@@ -3970,8 +3970,8 @@ ssf:
           # TODO: Fix since `centos-8` works
           # - [oraclelinux  ,    8   ,   master,      0,         default]
           # - [oraclelinux  ,    7   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
         yamllint:
           ignore:
@@ -4012,8 +4012,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_libsaltcli: true
         use_tofs: true
       semrel_files: *semrel_files_inc_map_jinja_verifier
@@ -4088,8 +4088,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,            suse]
           - [amazonlinux  ,    0   ,   master,      0,          redhat]
           - [oraclelinux  ,    0   ,   master,      0,          redhat]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files: *semrel_files_default
@@ -4144,8 +4144,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         yamllint:
           ignore:
             additional:
@@ -4621,8 +4621,8 @@ ssf:
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    8   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         yamllint:
           ignore:
             additional:
@@ -4746,8 +4746,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     telegraf:
@@ -4777,8 +4777,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     template:
@@ -4841,8 +4841,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,         default]
           - [amazonlinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    0   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           - [gentoo/stage3,    0   ,   master,      0,          gentoo]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_libsaltcli: true
         use_tofs: true
       semrel_files:
@@ -4982,8 +4982,8 @@ ssf:
           # # - [oraclelinux  ,    0   ,   master,      0,    without-ipv6]
           - [oraclelinux  ,    8   ,   master,      0,         default]
           - [oraclelinux  ,    7   ,   master,      0,    without-ipv6]
+          - [arch-base    ,    0   ,   master,      0,    without-ipv6]
           - [gentoo/stage3,    0   ,   master,      0,    without-ipv6]
-          - [arch-base    ,    0   ,   3003.0,      0,    without-ipv6]
         use_tofs: true
       semrel_files: *semrel_files_default
     users:
@@ -5041,8 +5041,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,           vimrc]
           - [amazonlinux  ,    0   ,   master,      0,           vimrc]
           - [oraclelinux  ,    0   ,   master,      0,           vimrc]
+          # # - [arch-base    ,    0   ,   master,      0,           vimrc]
           # # - [gentoo/stage3,    0   ,   master,      0,           vimrc]
-          # # - [arch-base    ,    0   ,   3003.0,      0,           vimrc]
       semrel_files: *semrel_files_default
     varnish:
       context:
@@ -5103,8 +5103,8 @@ ssf:
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
           - [oraclelinux  ,    8   ,   master,      0,         default]
+          - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          - [arch-base    ,    0   ,   3003.0,      0,         default]
         # TODO: Upgrade to latest TOFS in a subsequent PR, since a legacy version
         # is active for the time being (needs to be checked for regressions)
         use_tofs: legacy
@@ -5168,8 +5168,8 @@ ssf:
           - [opensuse/tmbl,    0   ,   master,      0,              '']
           - [amazonlinux  ,    0   ,   master,      0,              '']
           - [oraclelinux  ,    0   ,   master,      0,              '']
+          - [arch-base    ,    0   ,   master,      0,              '']
           # # - [gentoo/stage3,    0   ,   master,      0,              '']
-          - [arch-base    ,    0   ,   3003.0,      0,              '']
       semrel_files: *semrel_files_default
     vim:
       context:
@@ -5249,8 +5249,8 @@ ssf:
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
           # # - [oraclelinux  ,    0   ,   master,      0,         default]
+          # # - [arch-base    ,    0   ,   master,      0,         default]
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
-          # # - [arch-base    ,    0   ,   3003.0,      0,         default]
         use_tofs: true
         yamllint:
           rules:

--- a/ssf/libcimatrix.jinja
+++ b/ssf/libcimatrix.jinja
@@ -170,7 +170,7 @@
 {%-                 set comment = '# ' %}
 {#-                 Only include commented instances from the main platforms #}
 {#-                 Otherwise only use the first suite for the other platforms #}
-{%-                 if not (salt_ver == 'master' or [os, salt_ver] == ['arch-base', 3003.0]) %}
+{%-                 if not salt_ver == 'master' %}
 {%-                   if platform not in commented_platform_done %}
 {%-                     do commented_platform_done.append(platform) %}
 {%-                   else %}


### PR DESCRIPTION
Includes:

feat(saltimages): update with latest changes from `salt-image-builder`
    
* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/96