### PR TITLE
feat(salt): disable FreeBSD until pre-salted boxes updated

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(deps): bump '`'addressable'`' from '`'2.7.0'`' to '`'2.8.0'`' [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/340'
+            title: "ci(kitchen.vagrant.yml): disable FreeBSD until pre-salted boxes updated"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/341'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -4206,7 +4206,10 @@ ssf:
           # # - [arch-base    ,  latest,   3002.6,      3,       v3002-py3]
           # - [gentoo/stage3,  latest,   3002.6,      3,       v3002-py3]
           # - [gentoo/stage3, systemd,   3002.6,      3,       v3002-py3]
-          - [freebsd      ,    0   ,   3002.6,      3,       v3002-py3]
+          # # TODO: Re-enable once the pre-salted Vagrant boxes have been
+          # #       updated with the `py38-*`-based Salt packages
+          # #       See https://github.com/saltstack/salt-bootstrap/pull/1574
+          # - [freebsd      ,    0   ,   3002.6,      3,       v3002-py3]
           - [openbsd      ,    0   ,   3002.6,      3,       v3002-py3]
 
           ### `v3001-py3`


### PR DESCRIPTION
Re-enable once the pre-salted Vagrant boxes have been updated with the
`py38-*`-based Salt packages.

See:

* https://github.com/saltstack/salt-bootstrap/pull/1574