### PR TITLE
revert(nginx): disable failing instance until upstream issue resolved

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(kitchen.vagrant.yml): disable FreeBSD until pre-salted boxes updated"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/341'
+            title: "ci(gitlab-ci): enable instance after upstream issue resolved [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/342'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2866,11 +2866,7 @@ ssf:
           - [debian       ,    0   ,   master,      0,              '']
           # # - [ubuntu       ,    0   ,   master,      0,         default]
           - [ubuntu       ,    0   ,   master,      0,              '']
-          # # Use this again when the `passenger` issue is resolved
-          # # https://github.com/phusion/passenger/issues/2364#issuecomment-866313663
-          # # - [centos       ,    0   ,   master,      0,              '']
-          - [centos       ,    8   ,   master,      0,              '']
-          - [centos       ,    7   ,   master,      0,         default]
+          - [centos       ,    0   ,   master,      0,              '']
           - [fedora       ,    0   ,   master,      0,         default]
           - [opensuse/leap,    0   ,   master,      0,         default]
           - [opensuse/tmbl,    0   ,   master,      0,         default]


### PR DESCRIPTION
This reverts commit f638761348eec9debef00d6e83bc315886222c97.

Issue now resolved and confirmed by testing with Kitchen locally:

* https://github.com/phusion/passenger/issues/2364