### PR TITLE
feat(kitchen): move `provisioner` block & update `run_command`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile+lock): update to latest gem versions (2021-W28) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/343'
+            title: "ci(kitchen): move '`'provisioner'`' block & update '`'run_command'`' [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/344'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/kitchen.windows.yml
+++ b/ssf/files/default/kitchen.windows.yml
@@ -9,15 +9,6 @@ driver:
   username: {{ testing_windows.github.driver.username }}
   password: {{ testing_windows.github.driver.password }}
 
-platforms:
-  {%- for platform in proxyplatformswindows %}
-  {%-   set os       = platform[0] | d('') %}
-  {%-   set os_ver   = platform[1] | d('') %}
-  {%-   set salt_ver = platform[2] | d('') %}
-  {%-   set py_ver   = platform[3] | d('') %}
-  - name: {{ os | replace('/', '-') }}-{{ os_ver | replace('.', '') }}-{{ salt_ver | replace('.', '-') }}-py{{ py_ver }}
-  {%- endfor %}
-
 provisioner:
   salt_install: {{ testing_windows.github.platforms.provisioner.salt_install }}
   salt_bootstrap_options: {{ testing_windows.github.platforms.provisioner.salt_bootstrap_options }}
@@ -33,3 +24,12 @@ provisioner:
     {%- endfor %}
   # yamllint enable rule:line-length
   {%- endif %}
+
+platforms:
+  {%- for platform in proxyplatformswindows %}
+  {%-   set os       = platform[0] | d('') %}
+  {%-   set os_ver   = platform[1] | d('') %}
+  {%-   set salt_ver = platform[2] | d('') %}
+  {%-   set py_ver   = platform[3] | d('') %}
+  - name: {{ os | replace('/', '-') }}-{{ os_ver | replace('.', '') }}-{{ salt_ver | replace('.', '-') }}-py{{ py_ver }}
+  {%- endfor %}

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -161,10 +161,11 @@ provision_command:
 
 {%- macro format_driver_run_cmds(os, os_ver) %}
 {%-   filter indent(6) %}
-{%-     if os in ['opensuse/leap', 'opensuse/tmbl', 'arch-base'] %}
-run_command: /usr/lib/systemd/systemd
-{%-     elif [os, os_ver] in [['amazonlinux', 1], ['centos', 6], ['gentoo/stage3', 'latest']] %}
+{#-     Ordering of `if` and `elif` is important here, since we need to differentiate between the two Gentoo platforms #}
+{%-     if [os, os_ver] in [['gentoo/stage3', 'latest']] %}
 run_command: /sbin/init
+{%-     elif os in ['debian', 'ubuntu', 'gentoo'] %}
+run_command: /lib/systemd/systemd
 {%-     endif %}
 {%-   endfilter %}
 {%- endmacro %}
@@ -173,7 +174,7 @@ driver:
   name: docker
   use_sudo: false
   privileged: true
-  run_command: /lib/systemd/systemd
+  run_command: /usr/lib/systemd/systemd
   {%- set run_options = kitchen.driver.run_options %}
   {%- if run_options %}
   {%-   if semrel_formula == 'proftpd' %}

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -193,6 +193,16 @@ driver:
     {%- endfor %}
   {%- endif %}
 
+provisioner:
+  name: salt_solo
+  log_level: {{ 'info' if semrel_formula in ['devstack'] else 'debug' }}
+  salt_install: none
+  require_chef: false
+  formula: {{ semrel_formula }}
+  salt_copy_filter:
+    - .kitchen
+    - .git
+
 platforms:
 {#- Centralise duplication from here and `libcimatrix.jinja` #}
 {%- set ns_platforms = namespace(prev_comment='') %}
@@ -246,16 +256,6 @@ platforms:
       max_ssh_sessions: 1
     {%- endif %}
 {%- endfor %}
-
-provisioner:
-  name: salt_solo
-  log_level: {{ 'info' if semrel_formula in ['devstack'] else 'debug' }}
-  salt_install: none
-  require_chef: false
-  formula: {{ semrel_formula }}
-  salt_copy_filter:
-    - .kitchen
-    - .git
 
 verifier:
   # https://www.inspec.io/

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3871,6 +3871,7 @@ ssf:
                 - '*':
                     - ._mapdata
                     - states.files
+                    - .clean
                     - .
         map_jinja:
           verification:


### PR DESCRIPTION
* Move the `provisioner` block above `platforms`.
  - Ordering becomes `driver`, `provisioner`, `platforms`, `verifier` and finally `suites`.
  - The main reason is because `platforms` can override the general values provided under `provisioner`, similar to the `driver` overrides.
  - An example of this can be seen here:
    + https://github.com/saltstack/salt-bootstrap/blob/3690eeec50199954522e76c33fc7d49fc620fabf/kitchen.vagrant.yml#L14-L41
* Switch to a general `run_command` of `/usr/lib/systemd/systemd` instead of `/lib/systemd/systemd`.
  - There are actually more platforms that are based on that in reality.
  - Noticed the discrepancy between our `kitchen.yml` and the one in the `salt-bootstrap` repo and when investigating, found that ours wasn't accurate.
  - Relates to this merged PR: https://github.com/saltstack/salt-bootstrap/pull/1573 (for centralising the `run_command` amongst other things).
