### PR TITLE
feat: add Debian 11 Bullseye & update `yamllint` configuration

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,15 +5,17 @@
 extends: 'default'
 
 # Files to ignore completely
-# 1. All YAML files under directory `.cache/`, introduced during the GitLab CI run
-# 2. All YAML files under directory `.git/`
-# 3. All YAML files under directory `node_modules/`, introduced during the Travis run
-# 4. Any SLS files under directory `test/`, which are actually state files
-# 5. Any YAML files under directory `.kitchen/`, introduced during local testing
-# 6. `kitchen.vagrant.yml`, which contains Embedded Ruby (ERB) template syntax
-# 7. All Jinja templates under `ssf/files/` (result in `yamllint` syntax errors)
+# 1. All YAML files under directory `.bundle/`, introduced if gems are installed locally
+# 2. All YAML files under directory `.cache/`, introduced during the CI run
+# 3. All YAML files under directory `.git/`
+# 4. All YAML files under directory `node_modules/`, introduced during the CI run
+# 5. Any SLS files under directory `test/`, which are actually state files
+# 6. Any YAML files under directory `.kitchen/`, introduced during local testing
+# 7. `kitchen.vagrant.yml`, which contains Embedded Ruby (ERB) template syntax
+# 8. All Jinja templates under `ssf/files/` (result in `yamllint` syntax errors)
 #    Not disabling via. `*.yml` since we may end up with non-Jinja YAML files here
 ignore: |
+  .bundle/
   .cache/
   .git/
   node_modules/

--- a/ssf/config/formulas.sls
+++ b/ssf/config/formulas.sls
@@ -179,6 +179,7 @@ remove-previous-file-location-for-{{ formula }}-{{ dest_file }}:
         map_jinja: {{ map_jinja | yaml }}
         platforms: {{ context.platforms | yaml }}
         platforms_matrix: {{ context.platforms_matrix | yaml }}
+        platforms_matrix_allow_failure: {{ context.platforms_matrix_allow_failure | yaml }}
         platforms_matrix_commented_includes: {{ context.platforms_matrix_commented_includes | yaml }}
         proxyplatformswindows: {{ ssf.proxyplatformswindows | yaml }}
         rubocop: {{ context.rubocop | yaml }}

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -340,7 +340,6 @@ ssf:
     # - [fedora       ,   35   ,   tiamat,      3]  # fedo-35.0-tiamat-py3
     - [fedora       ,   35   ,   master,      3]  # fedo-35.0-master-py3
     - [fedora       ,   35   ,   3003.1,      3]  # fedo-35.0-3003.1-py3
-    - [fedora       ,   35   ,   3003.0,      3]  # fedo-35.0-3003.0-py3
     - [fedora       ,   35   ,   3002.6,      3]  # fedo-35.0-3002.6-py3
     - [fedora       ,   35   ,   3001.7,      3]  # fedo-35.0-3001.7-py3
   saltimages:
@@ -467,10 +466,6 @@ ssf:
     ### available; however, a latest version `git`-based image is available so using
     ### that instead to avoid numerous inconsistencies across the org
     ### Both issues from this formula and in the rendered files such as `kitchen.yml`
-    ### `3003.0-py3`
-    - [fedora       ,   34   ,   3003.0,      3]  # fedo-34.0-3003.0-py3
-    - [fedora       ,   33   ,   3003.0,      3]  # fedo-33.0-3003.0-py3
-
     ### `3002.5-py3`
     - [gentoo/stage3,  latest,   3002.5,      3]  # gent-late-3002.5-py3
     - [gentoo/stage3, systemd,   3002.5,      3]  # gent-sysd-3002.5-py3
@@ -496,6 +491,9 @@ ssf:
     - [ubuntu       ,   18.04,   3003.0,      3]  # ubun-18.0-3003.0-py3
     - [centos       ,    8   ,   3003.0,      3]  # cent-08.0-3003.0-py3
     - [centos       ,    7   ,   3003.0,      3]  # cent-07.0-3003.0-py3
+    - [fedora       ,   35   ,   3003.0,      3]  # fedo-35.0-3003.0-py3
+    - [fedora       ,   34   ,   3003.0,      3]  # fedo-34.0-3003.0-py3
+    - [fedora       ,   33   ,   3003.0,      3]  # fedo-33.0-3003.0-py3
     - [fedora       ,   32   ,   3003.0,      3]  # fedo-32.0-3003.0-py3
     # - [opensuse/leap,   15.3 ,   3003.0,      3]  # opsu-15.3-3003.0-py3
     # - [opensuse/leap,   15.2 ,   3003.0,      3]  # opsu-15.2-3003.0-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -237,6 +237,7 @@ ssf_node_anchors:
           extends: 'default'
           ignore:
             default:
+              - '.bundle/'
               - '.cache/'
               - '.git/'
               - 'node_modules/'

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -169,6 +169,9 @@ ssf_node_anchors:
           # - [gentoo/stage3,    0   ,   master,      0,         default]
           # - [almalinux    ,    0   ,   master,      0,         default]
           # - [rockylinux   ,    0   ,   master,      0,         default]
+        # Instances to allow failure for, such as new platforms which aren't
+        # currently working because waiting for upstream repos to be provided
+        platforms_matrix_allow_failure: []
         # To deal with excessive instances when mimicking `kitchen list -b`
         # If values are set, only use these as commented entries in the matrix
         platforms_matrix_commented_includes: []

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -344,6 +344,7 @@ ssf:
     - [fedora       ,   35   ,   3001.7,      3]  # fedo-35.0-3001.7-py3
   saltimages:
     ### `tiamat-py3`
+    - [debian       ,   11   ,   tiamat,      3]  # debi-11.0-tiamat-py3
     - [debian       ,   10   ,   tiamat,      3]  # debi-10.0-tiamat-py3
     - [debian       ,    9   ,   tiamat,      3]  # debi-09.0-tiamat-py3
     - [ubuntu       ,   20.04,   tiamat,      3]  # ubun-20.0-tiamat-py3
@@ -363,6 +364,7 @@ ssf:
     - [rockylinux   ,    8   ,   tiamat,      3]  # rock-08.0-tiamat-py3
 
     ### `master-py3`
+    - [debian       ,   11   ,   master,      3]  # debi-11.0-master-py3
     - [debian       ,   10   ,   master,      3]  # debi-10.0-master-py3
     - [debian       ,    9   ,   master,      3]  # debi-09.0-master-py3
     - [ubuntu       ,   20.04,   master,      3]  # ubun-20.0-master-py3
@@ -384,6 +386,7 @@ ssf:
     - [rockylinux   ,    8   ,   master,      3]  # rock-08.0-master-py3
 
     ### `3003.1-py3`
+    - [debian       ,   11   ,   3003.1,      3]  # debi-11.0-3003.1-py3
     - [debian       ,   10   ,   3003.1,      3]  # debi-10.0-3003.1-py3
     - [debian       ,    9   ,   3003.1,      3]  # debi-09.0-3003.1-py3
     - [ubuntu       ,   20.04,   3003.1,      3]  # ubun-20.0-3003.1-py3
@@ -403,6 +406,7 @@ ssf:
     - [gentoo/stage3, systemd,   3003.1,      3]  # gent-sysd-3003.1-py3
 
     ### `3002.6-py3`
+    - [debian       ,   11   ,   3002.6,      3]  # debi-11.0-3002.6-py3
     - [debian       ,   10   ,   3002.6,      3]  # debi-10.0-3002.6-py3
     - [debian       ,    9   ,   3002.6,      3]  # debi-09.0-3002.6-py3
     - [ubuntu       ,   20.04,   3002.6,      3]  # ubun-20.0-3002.6-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(kitchen): move '`'provisioner'`' block & update '`'run_command'`' [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/344'
+            title: "ci: add Debian 11 Bullseye & update '`'yamllint'`' configuration [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/345'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/.cirrus.yml
+++ b/ssf/files/default/.cirrus.yml
@@ -6,7 +6,7 @@ docker_builder:
   name: Test ${INSTANCE}
   env:
     matrix:
-      {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, width=6) }}
+      {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_allow_failure, platforms_matrix_commented_includes, semrel_formula, width=6) }}
   bundle_install_script: bundle install
   verify_script:
     {%- for pre_cmd in script_kitchen.pre %}

--- a/ssf/files/default/.github/workflows/kitchen.vagrant.yml
+++ b/ssf/files/default/.github/workflows/kitchen.vagrant.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, width=10, use_github_format=True, use_vagrant_platforms=True) }}
+          {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_allow_failure, platforms_matrix_commented_includes, semrel_formula, width=10, use_github_format=True, use_vagrant_platforms=True) }}
     {%- raw %}
     steps:
       - name: 'Check out code'

--- a/ssf/files/default/.github/workflows/kitchen.windows.yml
+++ b/ssf/files/default/.github/workflows/kitchen.windows.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, width=10, use_github_format=True, use_proxy_platforms_windows=platform) }}
+          {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_allow_failure, platforms_matrix_commented_includes, semrel_formula, width=10, use_github_format=True, use_proxy_platforms_windows=platform) }}
     {%- raw %}
     steps:
       - name: 'Check out code'

--- a/ssf/files/default/.github/workflows/kitchen.yml
+++ b/ssf/files/default/.github/workflows/kitchen.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, width=10, use_github_format=True) }}
+          {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_allow_failure, platforms_matrix_commented_includes, semrel_formula, width=10, use_github_format=True) }}
     {%- raw %}
     steps:
       - name: 'Check out code'

--- a/ssf/files/default/.gitlab-ci.yml
+++ b/ssf/files/default/.gitlab-ci.yml
@@ -176,7 +176,7 @@ rubocop:
     - 'bundle config set without "${BUNDLE_WITHOUT}"'
     - 'bundle install'
   script:
-    - '{{ script_kitchen.bin }} {{ script_kitchen.cmd }} default-debian-10-tiamat-py3'
+    - '{{ script_kitchen.bin }} {{ script_kitchen.cmd }} default-debian-11-master-py3'
 # REMOVEME>
 {%-   endif %}
 

--- a/ssf/files/default/.gitlab-ci.yml
+++ b/ssf/files/default/.gitlab-ci.yml
@@ -129,7 +129,7 @@ rubocop:
 ###############################################################################
 # Define `test` template
 ###############################################################################
-.test_instance:
+.test_instance:{{ ' &test_instance' if platforms_matrix_allow_failure else '' }}
   stage: *stage_test
   image: *image_dindruby
   services: *services_docker_dind
@@ -147,6 +147,16 @@ rubocop:
   script:
     # Alternative value to consider: `${CI_JOB_NAME}`
     - '{{ script_kitchen.bin }} {{ script_kitchen.cmd }} "${DOCKER_ENV_CI_JOB_NAME}"'
+
+{%-   if platforms_matrix_allow_failure %}
+
+###############################################################################
+# Define `test` template (`allow_failure: true`)
+###############################################################################
+.test_instance_failure_permitted:
+  <<: *test_instance
+  allow_failure: true
+{%-   endif %}
 
 {%-   if semrel_formula == 'template' %}
 # <REMOVEME
@@ -202,7 +212,7 @@ rubocop:
 test-formula-conversion: {extends: '.test_conversion'}
 # REMOVEME>
 {%-   endif %}
-{{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, width=0, use_gitlab_format=True) }}
+{{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_allow_failure, platforms_matrix_commented_includes, semrel_formula, width=0, use_gitlab_format=True) }}
 {%- endif %}
 
 ###############################################################################

--- a/ssf/files/default/.travis.yml
+++ b/ssf/files/default/.travis.yml
@@ -214,7 +214,7 @@ jobs:
     #       Ref: https://github.com/saltstack-formulas/template-formula/issues/118
     #       Ref: https://github.com/saltstack-formulas/template-formula/issues/121
     {%-   endif %}
-    {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_commented_includes, semrel_formula, use_new_travis_format=True) }}
+    {{- format_ci_matrix(platforms, inspec_suites_kitchen, inspec_suites_matrix, platforms_matrix, platforms_matrix_allow_failure, platforms_matrix_commented_includes, semrel_formula, use_new_travis_format=True) }}
     {%- endif %}
 
     {%- if semrel_formula == 'template' %}

--- a/ssf/files/default/.travis.yml
+++ b/ssf/files/default/.travis.yml
@@ -235,7 +235,7 @@ jobs:
         - '[ $(git rev-list HEAD --count) -eq 2 ]'
         # Quick visual check that correct files have been updated
         - git show --pretty="" --name-status
-        - bin/kitchen verify default-debian-10-tiamat-py3
+        - bin/kitchen verify default-debian-11-master-py3
     # REMOVEME>
     {%- endif %}
 

--- a/ssf/files/default/.yamllint
+++ b/ssf/files/default/.yamllint
@@ -15,19 +15,20 @@ ignore: |
 extends: '{{ yamllint.extends }}'
 
 # Files to ignore completely
-# 1. All YAML files under directory `.cache/`, introduced during the GitLab CI run
-# 2. All YAML files under directory `.git/`
-# 3. All YAML files under directory `node_modules/`, introduced during the Travis run
-# 4. Any SLS files under directory `test/`, which are actually state files
-# 5. Any YAML files under directory `.kitchen/`, introduced during local testing
-# 6. `kitchen.vagrant.yml`, which contains Embedded Ruby (ERB) template syntax
+# 1. All YAML files under directory `.bundle/`, introduced if gems are installed locally
+# 2. All YAML files under directory `.cache/`, introduced during the CI run
+# 3. All YAML files under directory `.git/`
+# 4. All YAML files under directory `node_modules/`, introduced during the CI run
+# 5. Any SLS files under directory `test/`, which are actually state files
+# 6. Any YAML files under directory `.kitchen/`, introduced during local testing
+# 7. `kitchen.vagrant.yml`, which contains Embedded Ruby (ERB) template syntax
 {%- if semrel_formula == 'ssf' %}
-# 7. All Jinja templates under `ssf/files/` (result in `yamllint` syntax errors)
+# 8. All Jinja templates under `ssf/files/` (result in `yamllint` syntax errors)
 #    Not disabling via. `*.yml` since we may end up with non-Jinja YAML files here
 {%- elif semrel_formula == 'mysql' %}
-# 7. Any YAML files using Jinja (result in `yamllint` syntax errors)
+# 8. Any YAML files using Jinja (result in `yamllint` syntax errors)
 {%- elif semrel_formula in ['postgres', 'salt'] %}
-# 7. All YAML files heavily reliant on Jinja; these can be tackled in a subsequent PR
+# 8. All YAML files heavily reliant on Jinja; these can be tackled in a subsequent PR
 {%- endif %}
 {%- set yl_ignores = {'ignore':
   yamllint.ignore.default +

--- a/ssf/files/default/kitchen.yml
+++ b/ssf/files/default/kitchen.yml
@@ -115,7 +115,7 @@ image: {{ 'saltimages' if [os, os_ver, salt_ver, py_ver] in saltimages else 'net
 {%-     endif %}
 {#-     General for all Salt versions #}
 {%-     if semrel_formula == 'packages' %}
-{%-       if [os, os_ver] in [['debian', 10], ['debian', 9]] %}
+{%-       if os in ['debian'] %}
 {%-         do prov_cmds.append('- apt-get update') %}
 {%-         do prov_cmds.append('- apt-get install --reinstall -y udev') %}
 {%-         do prov_cmds.append('- apt-get install -y snapd') %}

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3839,7 +3839,7 @@ ssf:
           - [fedora       ,    0   ,   master,      0,         default]
           - [opensuse/leap,    0   ,   master,      0,         default]
           - [opensuse/tmbl,    0   ,   master,      0,         default]
-          - [amazonlinux  ,    0   ,   master,      0,         default]
+          - [amazonlinux  ,    0   ,   master,      0,              '']
           - [oraclelinux  ,    0   ,   master,      0,              '']
           # TODO: Fix since `centos-8` works
           # - [oraclelinux  ,    8   ,   master,      0,         default]

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2891,6 +2891,8 @@ ssf:
           - [almalinux    ,    0   ,   master,      0,              '']
           - [rockylinux   ,    0   ,   master,      0,              '']
           - [freebsd      ,    0   ,   master,      3,         default]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,              '']
         testing_freebsd:
           active: true
         use_tofs: true
@@ -2990,6 +2992,8 @@ ssf:
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
           - [almalinux    ,    0   ,   master,      0,         default]
           - [rockylinux   ,    0   ,   master,      0,         default]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,            repo]
         # Use this to start adopting the latest `platforms_matrix`
         use_tofs: true
         yamllint:
@@ -3453,6 +3457,8 @@ ssf:
           - [almalinux    ,    0   ,   master,      0,         redhat8]
           - [rockylinux   ,    0   ,   master,      0,         redhat8]
           - [windows      ,    0   ,   latest,      3,         windows]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,          debian]
         testing_windows:
           active: true
       semrel_files: *semrel_files_default
@@ -3691,6 +3697,8 @@ ssf:
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
           - [almalinux    ,    0   ,   master,      0,         default]
           - [rockylinux   ,    0   ,   master,      0,         default]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,         default]
         yamllint:
           ignore:
             additional:
@@ -4054,6 +4062,8 @@ ssf:
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
           - [almalinux    ,    0   ,   master,      0,         default]
           - [rockylinux   ,    0   ,   master,      0,         default]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,         default]
         yamllint:
           ignore:
             additional:
@@ -4271,6 +4281,8 @@ ssf:
           ### `v3000-py2`
           - [ubuntu       ,   18.04,   3000.9,      2,       v3000-py2]
           # # - [arch-base    ,  latest,   3000.9,      2,       v3000-py2]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   3003.1,      3,       v3003-py3]
         testing_freebsd:
           active: true
         testing_openbsd:
@@ -4475,6 +4487,8 @@ ssf:
           verification:
             import: ['stunnel']
         platforms_matrix: *platforms_matrix_osfamily_debian
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,         default]
       semrel_files: *semrel_files_default
     sudoers:
       context:
@@ -4696,6 +4710,8 @@ ssf:
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
           - [almalinux    ,    0   ,   master,      0,         default]
           - [rockylinux   ,    0   ,   master,      0,         default]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
     template:
@@ -5035,6 +5051,8 @@ ssf:
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
           - [almalinux    ,    0   ,   master,      0,         default]
           - [rockylinux   ,    0   ,   master,      0,         default]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,         default]
         # TODO: Upgrade to latest TOFS in a subsequent PR, since a legacy version
         # is active for the time being (needs to be checked for regressions)
         use_tofs: legacy
@@ -5183,6 +5201,8 @@ ssf:
           # # - [gentoo/stage3,    0   ,   master,      0,         default]
           # # - [almalinux    ,    0   ,   master,      0,         default]
           # # - [rockylinux   ,    0   ,   master,      0,         default]
+        platforms_matrix_allow_failure:
+          - [debian       ,   11   ,   master,      3,         default]
         use_tofs: true
         yamllint:
           rules:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3795,6 +3795,7 @@ ssf:
         yamllint:
           ignore:
             additional:
+              - test/salt/pillar/debian.sls
               - test/salt/pillar/redhat.sls
       semrel_files: *semrel_files_default
     prometheus:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -443,7 +443,8 @@ ssf:
             import: ['apache']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,              '']  # modules
+          - [debian       ,   11   ,   master,      0,              '']  # modules
+          - [debian       ,   10   ,   master,      0,              '']  # modules
           - [ubuntu       ,    0   ,   master,      0,              '']  # modules
           - [centos       ,    0   ,   master,      0,              '']  # modules
           - [fedora       ,    0   ,   master,      0,              '']  # modules
@@ -1340,6 +1341,7 @@ ssf:
             import: ['firewall']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          - [debian       ,   11   ,   master,      0,         default]
           - [debian       ,   10   ,   master,      0,         default]
           - [debian       ,    9   ,   master,      0,              '']
           - [ubuntu       ,    0   ,   master,      0,              '']
@@ -2402,6 +2404,15 @@ ssf:
             import: ['letsencrypt']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
+          # # Fails with:
+          # # ```
+          # # requests.exceptions.SSLError: HTTPSConnectionPool(host='localhost',
+          # # port=14000): Max retries exceeded with url: /dir (Caused by
+          # # SSLError(SSLCertVerificationError(1, '[SSL:
+          # # CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get
+          # # local issuer certificate (_ssl.c:1123)')))
+          # # ```
+          # # - [debian       ,   11   ,   tiamat,      0,         domains]
           - [debian       ,   10   ,   tiamat,      0,         domains]
           - [debian       ,    0   ,   master,      0,             deb]
           - [ubuntu       ,   20.04,   tiamat,      0,         domains]
@@ -2437,7 +2448,7 @@ ssf:
           1:
             includes:
               # [os           ,  os_ver, salt_ver, py_ver]
-              - [debian       ,   10   ,   master,      3]
+              - [debian       ,   10   ,   master,      0]
             inspec_yml:
               summary: >-
                 Verify that the libvirt formula can cleanup correctly
@@ -2456,7 +2467,8 @@ ssf:
             import: ['mapdata']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   10   ,   master,      3,           clean]
+          - [debian       ,   11   ,   master,      0,           clean]
+          - [debian       ,   10   ,   master,      0,         default]
           - [debian       ,    9   ,   master,      0,         default]
           - [ubuntu       ,    0   ,   master,      0,         default]
           - [centos       ,    0   ,   master,      0,         default]
@@ -3880,6 +3892,7 @@ ssf:
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           # # - [debian       ,    0   ,   master,      0,         default]
+          - [debian       ,   11   ,   master,      0,         default]
           - [debian       ,   10   ,   master,      0,         default]
           # # - [ubuntu       ,    0   ,   master,      0,         default]
           - [ubuntu       ,   20.04,   master,      0,         default]
@@ -4027,6 +4040,7 @@ ssf:
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           # # - [debian       ,    0   ,   master,      0,         default]
+          - [debian       ,   11   ,   master,      0,         default]
           - [debian       ,   10   ,   master,      0,         default]
           # # - [ubuntu       ,    0   ,   master,      0,         default]
           - [ubuntu       ,   20.04,   master,      0,         default]
@@ -4163,7 +4177,8 @@ ssf:
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           ### `v3003-py3`
-          - [debian       ,   10   ,   3003.1,      3,       v3003-py3]
+          - [debian       ,   11   ,   3003.1,      3,       v3003-py3]
+          # - [debian       ,   10   ,   3003.1,      3,       v3003-py3]
           # - [debian       ,    9   ,   3003.1,      3,       v3003-py3]
           - [ubuntu       ,   20.04,   3003.1,      3,       v3003-py3]
           # - [ubuntu       ,   18.04,   3003.1,      3,       v3003-py3]
@@ -4191,8 +4206,9 @@ ssf:
           - [windows      ,    0   ,   latest,      3,       v3003-py3]
 
           ### `v3002-py3`
-          # - [debian       ,   10   ,   3002.6,      3,       v3002-py3]
-          - [debian       ,    9   ,   3002.6,      3,       v3002-py3]
+          # - [debian       ,   11   ,   3002.6,      3,       v3002-py3]
+          - [debian       ,   10   ,   3002.6,      3,       v3002-py3]
+          # - [debian       ,    9   ,   3002.6,      3,       v3002-py3]
           - [ubuntu       ,   20.04,   3002.6,      3,       v3002-py3]
           # - [ubuntu       ,   18.04,   3002.6,      3,       v3002-py3]
           # - [centos       ,    8   ,   3002.6,      3,       v3002-py3]
@@ -4217,6 +4233,7 @@ ssf:
           - [openbsd      ,    0   ,   3002.6,      3,       v3002-py3]
 
           ### `v3001-py3`
+          # - [debian       ,   11   ,   3001.7,      3,       v3001-py3]
           - [debian       ,   10   ,   3001.7,      3,       v3001-py3]
           # - [debian       ,    9   ,   3001.7,      3,       v3001-py3]
           - [ubuntu       ,   20.04,   3001.7,      3,       v3001-py3]
@@ -4236,6 +4253,7 @@ ssf:
           - [openbsd      ,    0   ,   3001.1,      3,       v3001-py3]
 
           ### `v3000-py3`
+          # - [debian       ,   11   ,   3000.9,      3,       v3000-py3]
           # - [debian       ,   10   ,   3000.9,      3,       v3000-py3]
           - [debian       ,    9   ,   3000.9,      3,       v3000-py3]
           - [ubuntu       ,   18.04,   3000.9,      3,       v3000-py3]
@@ -4838,6 +4856,7 @@ ssf:
         inspec_suites_kitchen:
           0:
             includes:
+              - [debian       ,   11   ,      0  ,      0]
               - [debian       ,   10   ,      0  ,      0]
               - [centos       ,    8   ,      0  ,      0]
               - [oraclelinux  ,    8   ,      0  ,      0]
@@ -4872,6 +4891,7 @@ ssf:
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           # # - [debian       ,    0   ,   master,      0,    without-ipv6]
+          - [debian       ,   11   ,   master,      0,         default]
           - [debian       ,   10   ,   master,      0,         default]
           - [debian       ,    9   ,   master,      0,    without-ipv6]
           - [ubuntu       ,    0   ,   master,      0,    without-ipv6]
@@ -4999,6 +5019,7 @@ ssf:
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           # # - [debian       ,    0   ,   master,      0,         default]
+          - [debian       ,   11   ,   master,      0,         default]
           - [debian       ,   10   ,   master,      0,         default]
           # # - [ubuntu       ,    0   ,   master,      0,         default]
           - [ubuntu       ,   20.04,   master,      0,         default]

--- a/ssf/libcimatrix.jinja
+++ b/ssf/libcimatrix.jinja
@@ -6,6 +6,7 @@
               inspec_suites_kitchen,
               inspec_suites_matrix,
               platforms_matrix,
+              platforms_matrix_allow_failure,
               platforms_matrix_commented_includes,
               semrel_formula,
               width=4,
@@ -184,6 +185,9 @@
 {%-               if use_gitlab_format %}
 {%-                 set list_format = '' %}
 {%-                 set test_template = ": {extends: '.test_instance'}" %}
+{%-                 if [os, os_ver, salt_ver, py_ver, suite_name] in platforms_matrix_allow_failure %}
+{%-                   set test_template = ": {extends: '.test_instance_failure_permitted'}" %}
+{%-                 endif %}
 {%-               else %}
 {%-                 set list_format = '- ' %}
 {%-                 set test_template = "" %}


### PR DESCRIPTION
```console
feat(saltimages): update with latest changes from `salt-image-builder`

* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/114
* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/115
```

* Main change here is introducing Debian 11 Bullseye pre-salted images.
* In order to use these Debian 11 images across all formulas, also had to implement the ability to use `allow_failures` for instances, since a number of formulas don't have upstream repos available for Bullseye yet.

Breakdown of where `allow_failures` has been used:

* Debian 11, awaiting upstream repo:
  - `nginx-formula` (`passenger` suite)
  - `node-formula`
  - `packages-formula` (which fails due to the dependency on the `node-formula`)
  - `powerdns-formula`
  - `rspamd-formula`
  - `salt-formula`
  - `telegraf-formula`
  - `varnish-formula`
  - `zabbix-formula`
* Debian 11, service enabling issue:
  - `stunnel-formula`

---

```console
feat(yamllint): add `.bundle/` to the default `ignore` list
```

* Justification given here:
  - https://github.com/saltstack-formulas/prometheus-formula/pull/60#issuecomment-880428271
