### PR TITLE
feat(formulas): add basic management for `Gemfile+lock` formulas

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -78,15 +78,19 @@ ssf:
       - apache
       - apt
       - apt-cacher
+      - backupninja
       - bind
       - cert
+      - charles
       - chrony
       - collectd
       - consul
       - cron
+      - dbeaver
       - deepsea
       - devstack
       - dhcpd
+      - diaspora
       - django
       - docker
       - eclipse
@@ -115,6 +119,7 @@ ssf:
       - jetbrains-rubymine
       - jetbrains-webstorm
       - keepalived
+      - kubernetes
       - letsencrypt
       - libvirt
       - locale
@@ -125,6 +130,7 @@ ssf:
       - maven
       - mongodb
       - mysql
+      - nextcloud
       - nfs
       - nginx
       - nifi
@@ -145,8 +151,10 @@ ssf:
       - rabbitmq
       - redis
       - rkhunter
+      - rlang
       - rng-tools
       - rspamd
+      - rstudio
       - salt
       - sqldeveloper
       - sqlplus
@@ -170,7 +178,9 @@ ssf:
       - vault
       - vim
       - vsftpd
+      - wireguard
       - zabbix
+      - zookeeper
     semrel_files:
       - .github/workflows/commitlint.yml
       - .github/workflows/kitchen.yml

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci: add Debian 11 Bullseye & update '`'yamllint'`' configuration [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/345'
+            title: "chore(gemfile+lock): update to latest gem versions (2021-W28) [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/346'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'
@@ -811,12 +811,15 @@ ssf:
             <<: *isk_suite_default
             name: ''
     apt-cacher: *formula_default
+    backupninja: *formula_default
     bind: *formula_default
     cert: *formula_default
+    charles: *formula_default
     chrony: *formula_default
     collectd: *formula_default
     consul: *formula_default
     cron: *formula_default
+    dbeaver: *formula_default
     deepsea: *formula_default
     devstack:
       <<: *formula_default
@@ -828,6 +831,7 @@ ssf:
             <<: *isk_suite_default
             name: 'ubuntu'
     dhcpd: *formula_default
+    diaspora: *formula_default
     django: *formula_default
     docker:
       <<: *formula_default
@@ -1021,6 +1025,7 @@ ssf:
             <<: *isk_suite_default
             name: 'arch'
     keepalived: *formula_default
+    kubernetes: *formula_default
     letsencrypt:
       <<: *formula_default
       context:
@@ -1093,6 +1098,7 @@ ssf:
             name: 'arch'
     mongodb: *formula_default
     mysql: *formula_default
+    nextcloud: *formula_default
     nfs: *formula_default
     nginx:
       <<: *formula_default
@@ -1249,8 +1255,10 @@ ssf:
           3:
             <<: *isk_suite_default
             name: 'suse'
+    rlang: *formula_default
     rng-tools: *formula_default
     rspamd: *formula_default
+    rstudio: *formula_default
     salt:
       <<: *formula_default
       context:
@@ -1342,4 +1350,6 @@ ssf:
             name: ''
     vim: *formula_default
     vsftpd: *formula_default
+    wireguard: *formula_default
     zabbix: *formula_default
+    zookeeper: *formula_default

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -378,6 +378,13 @@ ssf_node_anchors:
         inspec/controls/_mapdata.rb: &file__inspec__controls___mapdata--rb
           <<: *file_default
           template: 'jinja'
+      # Formulas only managed for the very basics, such as the `Gemfile+lock`,
+      # in order to avoid security warnings
+      semrel_files_mainly_gemfiles_only: &semrel_files_mainly_gemfiles_only
+        .github/workflows/commitlint.yml: *file__--github__workflows__commitlint--yml
+        CODEOWNERS: *file__CODEOWNERS
+        Gemfile: *file__Gemfile
+        Gemfile.lock: *file__Gemfile--lock
 
 ssf:
   semrel_formulas:
@@ -560,6 +567,20 @@ ssf:
         formula/libtofs.jinja:
           <<: *file__formula__libtofs--jinja
           dest_file: 'formula/ng/libtofs.jinja'
+    backupninja:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@alxwr'
+        git:
+          github:
+            repo: 'backupninja-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     # bareos:
     #   context:
     #     codeowners:
@@ -640,6 +661,20 @@ ssf:
             import: ['mapdata']
         use_libsaltcli: true
       semrel_files: *semrel_files_inc_map_jinja_verifier
+    charles:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@noelmcloughlin'
+        git:
+          github:
+            repo: 'charles-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     chrony:
       context:
         git:
@@ -735,6 +770,20 @@ ssf:
             import: ['cron']
         platforms_matrix: *platforms_matrix_without_gentoo
       semrel_files: *semrel_files_default
+    dbeaver:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@noelmcloughlin'
+        git:
+          github:
+            repo: 'dbeaver-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     deepsea:
       context:
         codeowners:
@@ -841,6 +890,20 @@ ssf:
           # # - [almalinux    ,    0   ,   master,      0,         default]
           # # - [rockylinux   ,    0   ,   master,      0,         default]
       semrel_files: *semrel_files_inc_map_jinja_verifier
+    diaspora:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@SuperTux88'
+        git:
+          github:
+            repo: 'diaspora-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     django:
       context:
         git:
@@ -2310,6 +2373,20 @@ ssf:
                 - ipvsadm
         use_tofs: true
       semrel_files: *semrel_files_default
+    kubernetes:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@noelmcloughlin'
+        git:
+          github:
+            repo: 'kubernetes-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     letsencrypt:
       context:
         codeowners:
@@ -2773,6 +2850,20 @@ ssf:
             additional:
               - mysql/supported_sections.yaml
       semrel_files: *semrel_files_default
+    nextcloud:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@alxwr'
+        git:
+          github:
+            repo: 'nextcloud-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     nfs:
       context:
         git:
@@ -3996,6 +4087,20 @@ ssf:
         travis: *travis_do_not_use_single_job_for_linters
         use_tofs: true
       semrel_files: *semrel_files_default
+    rlang:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@noelmcloughlin'
+        git:
+          github:
+            repo: 'rlang-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     rng-tools:
       context:
         codeowners:
@@ -4075,6 +4180,20 @@ ssf:
     #       entries:
     #         global:
     #           - '*': '@sticky-note'
+    rstudio:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@noelmcloughlin'
+        git:
+          github:
+            repo: 'rstudio-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     salt:
       context:
         codeowners:
@@ -5156,6 +5275,20 @@ ssf:
         # Gentoo (OpenRC): Service `vsftpd' needs non existent service `net'
         platforms_matrix: *platforms_matrix_without_gentoo_non_systemd
       semrel_files: *semrel_files_default
+    wireguard:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@alxwr'
+        git:
+          github:
+            repo: 'wireguard-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     zabbix:
       context:
         codeowners:
@@ -5209,3 +5342,17 @@ ssf:
             key-duplicates:
               ignore: *ignore_pillar_example
       semrel_files: *semrel_files_default
+    zookeeper:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@codeboyQ2n5ha45'
+        git:
+          github:
+            repo: 'zookeeper-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only


### PR DESCRIPTION
These formulas also show up on the security warnings for the
organisation; ideally, they should be managed like the rest of the
formulas but implementing a basic solution for the `Gemfile` and
`Gemfile.lock` files right now.  Also includes management of the
`commitlint` GitHub Action as well as the `CODEOWNERS` file.

* backupninja-formula
* charles-formula
* dbeaver-formula
* diaspora-formula
* kubernetes-formula
* nextcloud-formula
* rlang-formula
* rstudio-formula
* wireguard-formula
* zookeeper-formula