### PR TITLE
feat(formulas): add basic management for `Gemfile+lock` formulas (previously commented out)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -75,10 +75,12 @@ ssf:
   ### State the formulas and files to work through when running the formula
   active:
     semrel_formulas:
+      - aegir
       - apache
       - apt
       - apt-cacher
       - backupninja
+      - bareos
       - bind
       - cert
       - charles
@@ -155,6 +157,7 @@ ssf:
       - rng-tools
       - rspamd
       - rstudio
+      - rundeck
       - salt
       - sqldeveloper
       - sqlplus

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -65,7 +65,7 @@ ssf_node_anchors:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
             title: "chore(gemfile+lock): update to latest gem versions (2021-W28) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/346'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/347'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'
@@ -780,6 +780,7 @@ ssf:
 
   semrel_formulas:
     .github: *formula_default
+    aegir: *formula_default
     apache:
       <<: *formula_default
       context:
@@ -812,6 +813,7 @@ ssf:
             name: ''
     apt-cacher: *formula_default
     backupninja: *formula_default
+    bareos: *formula_default
     bind: *formula_default
     cert: *formula_default
     charles: *formula_default
@@ -1259,6 +1261,7 @@ ssf:
     rng-tools: *formula_default
     rspamd: *formula_default
     rstudio: *formula_default
+    rundeck: *formula_default
     salt:
       <<: *formula_default
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -402,12 +402,20 @@ ssf:
         docs/CONTRIBUTING.rst:
           <<: *file__docs__CONTRIBUTING--rst
           dest_file: 'CONTRIBUTING.rst'
-    # aegir:
-    #   context:
-    #     codeowners:
-    #       entries:
-    #         global:
-    #           - '*': '@javierbertoli'
+    aegir:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@javierbertoli'
+        git:
+          github:
+            repo: 'aegir-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     apache:
       context:
         codeowners:
@@ -581,12 +589,20 @@ ssf:
         platforms: []
         platforms_matrix: []
       semrel_files: *semrel_files_mainly_gemfiles_only
-    # bareos:
-    #   context:
-    #     codeowners:
-    #       entries:
-    #         global:
-    #           - '*': '@javierbertoli'
+    bareos:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@javierbertoli'
+        git:
+          github:
+            repo: 'bareos-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     bind:
       context:
         codeowners:
@@ -4174,12 +4190,6 @@ ssf:
             additional:
               - rspamd/osfamilymap.yaml
       semrel_files: *semrel_files_default
-    # rundeck:
-    #   context:
-    #     codeowners:
-    #       entries:
-    #         global:
-    #           - '*': '@sticky-note'
     rstudio:
       context:
         codeowners:
@@ -4189,6 +4199,20 @@ ssf:
         git:
           github:
             repo: 'rstudio-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
+    rundeck:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@sticky-note'
+        git:
+          github:
+            repo: 'rundeck-formula'
         inspec_suites_kitchen: {}
         inspec_suites_matrix: []
         platforms: []

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -1665,10 +1665,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'appcode'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'appcode'
     jetbrains-clion:
       context:
         codeowners:
@@ -1735,10 +1731,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'clion'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'clion'
     jetbrains-datagrip:
       context:
         codeowners:
@@ -1805,10 +1797,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'datagrip'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'datagrip'
     jetbrains-goland:
       context:
         codeowners:
@@ -1875,10 +1863,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'goland'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'goland'
     jetbrains-intellij:
       context:
         codeowners:
@@ -1961,10 +1945,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'intellij'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'intellij'
     jetbrains-phpstorm:
       context:
         codeowners:
@@ -2031,10 +2011,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'phpstorm'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'phpstorm'
     jetbrains-pycharm:
       context:
         codeowners:
@@ -2103,10 +2079,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'pycharm'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'pycharm'
     jetbrains-resharper:
       context:
         codeowners:
@@ -2150,10 +2122,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'resharper'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'resharper'
     jetbrains-rider:
       context:
         codeowners:
@@ -2220,10 +2188,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'rider'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'rider'
     jetbrains-rubymine:
       context:
         codeowners:
@@ -2290,10 +2254,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'rubymine'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'rubymine'
     jetbrains-webstorm:
       context:
         codeowners:
@@ -2360,10 +2320,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'webstorm'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'webstorm'
     keepalived:
       context:
         git:
@@ -4760,10 +4716,6 @@ ssf:
         kitchen.yml:
           <<: *file__kitchen--yml
           alt_semrel_formula: 'syslog_ng'
-    #     # Overrides for extra files in `*semrel_files_inc_map_jinja_verifier`
-    #     inspec/controls/_mapdata.rb:
-    #       <<: *file__inspec__controls___mapdata--rb
-    #       alt_semrel_formula: 'syslog_ng'
     sysstat:
       context:
         git:


### PR DESCRIPTION
These formulas were already "available" here, commented out, for future
`CODEOWNERS` inclusion.  This commit finally makes use of those, as well
as managing the gems there.

* aegir-formula
* bareos-formula
* rundeck-formula