### PR TITLE
feat(saltimages): update with latest changes from `salt-image-builder` (`3003.2`)

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -348,7 +348,7 @@ ssf:
     ### Already available but not using across the Formulas' org until released
     # - [fedora       ,   35   ,   tiamat,      3]  # fedo-35.0-tiamat-py3
     - [fedora       ,   35   ,   master,      3]  # fedo-35.0-master-py3
-    - [fedora       ,   35   ,   3003.1,      3]  # fedo-35.0-3003.1-py3
+    - [fedora       ,   35   ,   3003.2,      3]  # fedo-35.0-3003.2-py3
     - [fedora       ,   35   ,   3002.6,      3]  # fedo-35.0-3002.6-py3
     - [fedora       ,   35   ,   3001.7,      3]  # fedo-35.0-3001.7-py3
   saltimages:
@@ -394,22 +394,30 @@ ssf:
     - [almalinux    ,    8   ,   master,      3]  # alma-08.0-master-py3
     - [rockylinux   ,    8   ,   master,      3]  # rock-08.0-master-py3
 
+    ### `3003.2-py3`
+    - [debian       ,   11   ,   3003.2,      3]  # debi-11.0-3003.2-py3
+    - [debian       ,   10   ,   3003.2,      3]  # debi-10.0-3003.2-py3
+    - [debian       ,    9   ,   3003.2,      3]  # debi-09.0-3003.2-py3
+    - [ubuntu       ,   20.04,   3003.2,      3]  # ubun-20.0-3003.2-py3
+    - [ubuntu       ,   18.04,   3003.2,      3]  # ubun-18.0-3003.2-py3
+    - [centos       ,    8   ,   3003.2,      3]  # cent-08.0-3003.2-py3
+    - [centos       ,    7   ,   3003.2,      3]  # cent-07.0-3003.2-py3
+    - [fedora       ,   34   ,   3003.2,      3]  # fedo-34.0-3003.2-py3
+    - [fedora       ,   33   ,   3003.2,      3]  # fedo-33.0-3003.2-py3
+    - [opensuse/leap,   15.3 ,   3003.2,      3]  # opsu-15.3-3003.2-py3
+    - [opensuse/leap,   15.2 ,   3003.2,      3]  # opsu-15.2-3003.2-py3
+    - [opensuse/tmbl,  latest,   3003.2,      3]  # opsu-tmbl-3003.2-py3
+    - [amazonlinux  ,    2   ,   3003.2,      3]  # amaz-02.0-3003.2-py3
+    - [oraclelinux  ,    8   ,   3003.2,      3]  # orac-08.0-3003.2-py3
+    - [oraclelinux  ,    7   ,   3003.2,      3]  # orac-07.0-3003.2-py3
+    - [arch-base    ,  latest,   3003.2,      3]  # arch-late-3003.2-py3
+    - [gentoo/stage3,  latest,   3003.2,      3]  # gent-late-3003.2-py3
+    - [gentoo/stage3, systemd,   3003.2,      3]  # gent-sysd-3003.2-py3
+    - [almalinux    ,    8   ,   3003.2,      3]  # alma-08.0-3003.2-py3
+
     ### `3003.1-py3`
-    - [debian       ,   11   ,   3003.1,      3]  # debi-11.0-3003.1-py3
-    - [debian       ,   10   ,   3003.1,      3]  # debi-10.0-3003.1-py3
-    - [debian       ,    9   ,   3003.1,      3]  # debi-09.0-3003.1-py3
-    - [ubuntu       ,   20.04,   3003.1,      3]  # ubun-20.0-3003.1-py3
-    - [ubuntu       ,   18.04,   3003.1,      3]  # ubun-18.0-3003.1-py3
-    - [centos       ,    8   ,   3003.1,      3]  # cent-08.0-3003.1-py3
-    - [centos       ,    7   ,   3003.1,      3]  # cent-07.0-3003.1-py3
-    - [fedora       ,   34   ,   3003.1,      3]  # fedo-34.0-3003.1-py3
-    - [fedora       ,   33   ,   3003.1,      3]  # fedo-33.0-3003.1-py3
-    - [opensuse/leap,   15.3 ,   3003.1,      3]  # opsu-15.3-3003.1-py3
-    - [opensuse/leap,   15.2 ,   3003.1,      3]  # opsu-15.2-3003.1-py3
-    - [opensuse/tmbl,  latest,   3003.1,      3]  # opsu-tmbl-3003.1-py3
-    - [amazonlinux  ,    2   ,   3003.1,      3]  # amaz-02.0-3003.1-py3
-    - [oraclelinux  ,    8   ,   3003.1,      3]  # orac-08.0-3003.1-py3
-    - [oraclelinux  ,    7   ,   3003.1,      3]  # orac-07.0-3003.1-py3
+    ### Add these to `saltimages_deprecated_stable_by_git` once no longer
+    ### needed for the `salt-formula` CI
     - [arch-base    ,  latest,   3003.1,      3]  # arch-late-3003.1-py3
     - [gentoo/stage3,  latest,   3003.1,      3]  # gent-late-3003.1-py3
     - [gentoo/stage3, systemd,   3003.1,      3]  # gent-sysd-3003.1-py3
@@ -497,6 +505,25 @@ ssf:
     - [fedora       ,   32   ,   master,      3]  # fedo-32.0-master-py3
     - [fedora       ,   31   ,   master,      3]  # fedo-31.0-master-py3
 
+    ### `3003.1-py3`
+    - [debian       ,   11   ,   3003.1,      3]  # debi-11.0-3003.1-py3
+    - [debian       ,   10   ,   3003.1,      3]  # debi-10.0-3003.1-py3
+    - [debian       ,    9   ,   3003.1,      3]  # debi-09.0-3003.1-py3
+    - [ubuntu       ,   20.04,   3003.1,      3]  # ubun-20.0-3003.1-py3
+    - [ubuntu       ,   18.04,   3003.1,      3]  # ubun-18.0-3003.1-py3
+    - [centos       ,    8   ,   3003.1,      3]  # cent-08.0-3003.1-py3
+    - [centos       ,    7   ,   3003.1,      3]  # cent-07.0-3003.1-py3
+    - [fedora       ,   35   ,   3003.1,      3]  # fedo-35.0-3003.1-py3
+    - [fedora       ,   34   ,   3003.1,      3]  # fedo-34.0-3003.1-py3
+    - [fedora       ,   33   ,   3003.1,      3]  # fedo-33.0-3003.1-py3
+    # - [opensuse/leap,   15.3 ,   3003.1,      3]  # opsu-15.3-3003.1-py3
+    # - [opensuse/leap,   15.2 ,   3003.1,      3]  # opsu-15.2-3003.1-py3
+    # - [opensuse/tmbl,  latest,   3003.1,      3]  # opsu-tmbl-3003.1-py3
+    - [amazonlinux  ,    2   ,   3003.1,      3]  # amaz-02.0-3003.1-py3
+    - [oraclelinux  ,    8   ,   3003.1,      3]  # orac-08.0-3003.1-py3
+    - [oraclelinux  ,    7   ,   3003.1,      3]  # orac-07.0-3003.1-py3
+    - [almalinux    ,    8   ,   3003.1,      3]  # alma-08.0-3003.1-py3
+
     ### `3003.0-py3`
     - [debian       ,   10   ,   3003.0,      3]  # debi-10.0-3003.0-py3
     - [debian       ,    9   ,   3003.0,      3]  # debi-09.0-3003.0-py3
@@ -517,6 +544,7 @@ ssf:
     - [arch-base    ,  latest,   3003.0,      3]  # arch-late-3003.0-py3
     - [gentoo/stage3,  latest,   3003.0,      3]  # gent-late-3003.0-py3
     - [gentoo/stage3, systemd,   3003.0,      3]  # gent-sysd-3003.0-py3
+    - [almalinux    ,    8   ,   3003.0,      3]  # alma-08.0-3003.0-py3
 
     ### `3002.6-py3`
     - [ubuntu       ,   16.04,   3002.6,      3]  # ubun-16.0-3002.6-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile.lock): update to latest gem versions (2021-W33) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/359'
+            title: "ci(kitchen+ci): update with latest '`'3003.2'`' pre-salted images [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/360'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -4235,6 +4235,7 @@ ssf:
           0:
             includes:
               # [os           ,  os_ver, salt_ver, py_ver]
+              - [0            ,    0   ,   3003.2,      3]
               - [0            ,    0   ,   3003.1,      3]
               - [windows      ,    0   ,   latest,      3]
             inspec_yml:
@@ -4327,32 +4328,39 @@ ssf:
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           ### `v3003-py3`
-          - [debian       ,   11   ,   3003.1,      3,       v3003-py3]
-          # - [debian       ,   10   ,   3003.1,      3,       v3003-py3]
-          # - [debian       ,    9   ,   3003.1,      3,       v3003-py3]
-          - [ubuntu       ,   20.04,   3003.1,      3,       v3003-py3]
-          # - [ubuntu       ,   18.04,   3003.1,      3,       v3003-py3]
-          - [centos       ,    8   ,   3003.1,      3,       v3003-py3]
-          # - [centos       ,    7   ,   3003.1,      3,       v3003-py3]
+          - [debian       ,   11   ,   3003.2,      3,       v3003-py3]
+          # - [debian       ,   10   ,   3003.2,      3,       v3003-py3]
+          # - [debian       ,    9   ,   3003.2,      3,       v3003-py3]
+          - [ubuntu       ,   20.04,   3003.2,      3,       v3003-py3]
+          # - [ubuntu       ,   18.04,   3003.2,      3,       v3003-py3]
+          - [centos       ,    8   ,   3003.2,      3,       v3003-py3]
+          # - [centos       ,    7   ,   3003.2,      3,       v3003-py3]
           # # Unavailable below since only installs `3003.X`
-          - [fedora       ,   34   ,   3003.1,      3,       v3003-py3]
-          - [fedora       ,   33   ,   3003.1,      3,       v3003-py3]
-          # # TODO: Fix when `3003.1` released; however, see the note below about
+          - [fedora       ,   34   ,   3003.2,      3,       v3003-py3]
+          - [fedora       ,   33   ,   3003.2,      3,       v3003-py3]
+          # # TODO: Fix when `3003.2` released; however, see the note below about
           # #       using either `15.3` or `15.2` due to a shared `_mapdata`
           # #       verification file within the same InSpec suite
-          # # - [opensuse/leap,   15.3 ,   3003.1,      3,       v3003-py3]
-          # # - [opensuse/leap,   15.2 ,   3003.1,      3,       v3003-py3]
-          # # - [opensuse/tmbl,  latest,   3003.1,      3,       v3003-py3]
-          - [amazonlinux  ,    2   ,   3003.1,      3,       v3003-py3]
-          - [oraclelinux  ,    8   ,   3003.1,      3,       v3003-py3]
-          # - [oraclelinux  ,    7   ,   3003.1,      3,       v3003-py3]
+          # # - [opensuse/leap,   15.3 ,   3003.2,      3,       v3003-py3]
+          # # - [opensuse/leap,   15.2 ,   3003.2,      3,       v3003-py3]
+          # # - [opensuse/tmbl,  latest,   3003.2,      3,       v3003-py3]
+          - [amazonlinux  ,    2   ,   3003.2,      3,       v3003-py3]
+          - [oraclelinux  ,    8   ,   3003.2,      3,       v3003-py3]
+          # - [oraclelinux  ,    7   ,   3003.2,      3,       v3003-py3]
+          # # TODO: Fix when `3003.2` released
+          # - [arch-base    ,  latest,   3003.2,      3,       v3003-py3]
           - [arch-base    ,  latest,   3003.1,      3,       v3003-py3]
+          # # TODO: Fix when `3003.2` released
+          # - [gentoo/stage3,  latest,   3003.2,      3,       v3003-py3]
+          # - [gentoo/stage3, systemd,   3003.2,      3,       v3003-py3]
           - [gentoo/stage3,  latest,   3003.1,      3,       v3003-py3]
           - [gentoo/stage3, systemd,   3003.1,      3,       v3003-py3]
-          # # TODO: When supported in an official release, move these two platforms
+          - [almalinux    ,    8   ,   3003.2,      3,       v3003-py3]
+          # # TODO: When supported in an official release, move this platform
           # #       to that release (as a minimum, no other Salt versions)
-          - [almalinux    ,    0   ,   3003.1,      3,       v3003-py3]
-          - [rockylinux   ,    0   ,   3003.1,      3,       v3003-py3]
+          - [rockylinux   ,    0   ,   3003.2,      3,       v3003-py3]
+          # # FreeBSD and Windows won't always be in sync with the Linux
+          # # platforms above
           - [freebsd      ,    0   ,   3003.1,      3,       v3003-py3]
           - [windows      ,    0   ,   latest,      3,       v3003-py3]
 
@@ -4419,7 +4427,7 @@ ssf:
           - [ubuntu       ,   18.04,   3000.9,      2,       v3000-py2]
           # # - [arch-base    ,  latest,   3000.9,      2,       v3000-py2]
         platforms_matrix_allow_failure:
-          - [debian       ,   11   ,   3003.1,      3,       v3003-py3]
+          - [debian       ,   11   ,   3003.2,      3,       v3003-py3]
         testing_freebsd:
           active: true
         testing_openbsd:
@@ -4429,7 +4437,7 @@ ssf:
           github:
             platforms:
               provisioner:
-                salt_bootstrap_options: '-pythonVersion 3 -version 3003.1'
+                salt_bootstrap_options: '-pythonVersion 3 -version 3003.2'
           winrepo_ng: ['salt-minion-py3']
         use_tofs: true
         yamllint:


### PR DESCRIPTION
* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/118
* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/120
  - Removed AlmaLinux `3003.1` & `3003.0` without an MR (i.e. in a separate commit)
  - https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/commit/dda500ba9da7