### PR TITLE
feat(packages): manage `map.jinja` verification

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile.lock): update to latest gem versions (2021-W39) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/370'
+            title: "test(map): verify '`'map.jinja'`' dump using '`'_mapdata'`' state"
+            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/371'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3381,6 +3381,7 @@ ssf:
             provisioner:
               dependencies:
                 - name: 'node'
+                  branch: 'test-kitchen'
                   repo: 'git'
                   source: 'https://github.com/saltstack-formulas/node-formula.git'
               pillars_from_files:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3503,6 +3503,7 @@ ssf:
                 - .sls: 'test/salt/pillar/windows.sls'
               state_top:
                 - '*':
+                    - ._mapdata
                     - .chocolatey
         inspec_suites_matrix:
           - default
@@ -3543,7 +3544,7 @@ ssf:
           - [debian       ,   11   ,   master,      3,          debian]
         testing_windows:
           active: true
-      semrel_files: *semrel_files_default
+      semrel_files: *semrel_files_inc_map_jinja_verifier
     php:
       context:
         codeowners:


### PR DESCRIPTION
Also contains temporary fix for the `node-formula` CI dependency until the following PR is finalised and merged:

* https://github.com/saltstack-formulas/node-formula/pull/59