### PR TITLE
feat(antora): add initial support (only for `apache-formula` currently)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
       - id: shellcheck
         name: Check shell scripts with shellcheck
         files: ^.*\.(sh|bash|ksh)$
+        exclude: 'ssf/files/default/pre-commit_semantic-release.sh'
         types: []
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.23.0

--- a/ssf/files/default/.gitlab-ci.yml
+++ b/ssf/files/default/.gitlab-ci.yml
@@ -38,7 +38,13 @@
     name: 'myii/ssf-pre-commit:2.9.2'
     entrypoint: ['/bin/bash', '-c']
   image_rubocop: &image_rubocop 'pipelinecomponents/rubocop:latest'
+  {#- Temporary hack required until all formulas are converted over to use with Antora #}
+  {%-   if semrel_formula in ['apache'] %}
+  # yamllint disable-line rule:line-length
+  image_semantic-release: &image_semanticrelease 'myii/ssf-semantic-release-pandoc:15.14'
+  {%-   else %}
   image_semantic-release: &image_semanticrelease 'myii/ssf-semantic-release:15.14'
+  {%-   endif  %}
   {%- if use_stage_test %}
   # `services`
   services_docker_dind: &services_docker_dind

--- a/ssf/files/default/.pre-commit-config.yaml
+++ b/ssf/files/default/.pre-commit-config.yaml
@@ -33,6 +33,9 @@ repos:
       - id: shellcheck
         name: Check shell scripts with shellcheck
         files: ^.*\.(sh|bash|ksh)$
+        {%- if semrel_formula == 'ssf' %}
+        exclude: 'ssf/files/default/pre-commit_semantic-release.sh'
+        {%- endif  %}
         types: []
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.23.0

--- a/ssf/files/default/pre-commit_semantic-release.sh
+++ b/ssf/files/default/pre-commit_semantic-release.sh
@@ -28,3 +28,93 @@ sed -i -e '1,4s/-/=/g' CHANGELOG.rst
 
 # Return back to the main directory
 cd ..
+{%- if semrel_formula in ["apache"] %}
+
+
+###############################################################################
+# (C) Make all adjustments related to the Antora-based documentation
+#     This needs to run after the conversion to `.rst` since it uses
+#     those files to convert to `.adoc`
+###############################################################################
+
+# Update `docs/antora.yml` with `${nextRelease.version}`
+sed -i -e "/^\(version: '\).*\('\)$/s//\1${1}\2/" docs/antora.yml
+
+# Convert the files from `.rst` to `.adoc` using `pandoc`
+FROM=rst && FN=CHANGELOG && pandoc -t asciidoctor -f ${FROM} -o docs/modules/ROOT/pages/${FN}.adoc docs/${FN}.${FROM}
+FROM=rst && FN=AUTHORS && pandoc -t asciidoctor -f ${FROM} -o docs/modules/ROOT/pages/${FN}.adoc docs/${FN}.${FROM}
+FROM=rst && FN=README && pandoc -t asciidoctor -f ${FROM} -o docs/modules/ROOT/pages/${FN}.adoc docs/${FN}.${FROM}
+
+# Adjust `CHANGELOG.adoc`
+ADOC="docs/modules/ROOT/pages/CHANGELOG.adoc"
+# Fix links to avoid issue with `...` in URL
+# Also ensure each of these links opens in a new tab
+sed -i -e '/^\(=== \)\(https.*\)\(\[.*\)\(]\)/s//\1link:++\2++\3^\4/' "${ADOC}"
+# Open other standard links in new tabs
+sed -i -e '/^\((https.*\)\(]\)/s//\1^\2/' "${ADOC}"
+sed -i -e '/^\(https.*\)\(]\)/s//\1^\2/' "${ADOC}"
+# And other non-standard links
+# shellcheck disable=SC2016
+sed -i -e '\_^\((https.*/commit/\)\(.......\)\()\)$_s__\1\2[\2^]\3_' "${ADOC}"
+# Fix headings throughout file
+sed -i -e '/^=/s///' "${ADOC}"
+# Fix `[skip ci]` on line by itself
+sed -i -e '/^\[skip ci]$/s// &/' "${ADOC}"
+# Fix what looks like Asciidoctor variables, i.e. in curly braces `{...}`
+sed -i -e '/{\w\+}/s//\\&/' "${ADOC}"
+# Add `:sectnums!:` directly after the title (the blank line in-between is necessary)
+sed -i -e '2 i \\n:sectnums!:' "${ADOC}"
+
+# Adjust `AUTHORS.adoc`
+ADOC="docs/modules/ROOT/pages/AUTHORS.adoc"
+# Fix the heading
+sed -i -e '/^=/s///' "${ADOC}"
+# Run three times to get all four lines joined
+# (most entries only need two joins but that's dealt with below)
+sed -i -e '/^|:raw-html-m2r/N;s/\n/ /' "${ADOC}"
+sed -i -e '/^|:raw-html-m2r/N;s/\n/ /' "${ADOC}"
+sed -i -e '/^|:raw-html-m2r/N;s/\n/ /' "${ADOC}"
+# Add blank line in-between
+sed -i -e '/^|:raw-html-m2r/{G;}' "${ADOC}"
+# Clear up any double-blank lines introduced
+sed -i -e '/^$/N;/\n$/D' "${ADOC}"
+# Split the lines again on the table delimeter
+sed -i -e '/^|:raw-html-m2r/s/ |/\n|/g' "${ADOC}"
+# Fix the `raw-html-m2r` to link to the GitHub avatar images correctly
+sed -i -e "/^\(|\):raw-html-m2r.*src='\(.*\)' width='\(.*\)' height='\(.*\)' alt='\(.*\)'.*/s//\1image::\2[\5,\3,\4]/" "${ADOC}"
+# Reduce the table boundary markers
+sed -i -e '/^|===.*/s//|===/' "${ADOC}"
+# Reduce the table boundary markers
+sed -i -e '/^|Avatar |Contributor |Contributions/s//^.^|Avatar\n<.^|Contributor\n^.^|Contributions\n/' "${ADOC}"
+# Fix the table heading
+sed -i -e '/^\[cols=".*/s//.List of contributors\n[format="psv", separator="|", options="header", cols="^.<30a,<.<40a,^.<40d", width="100"]/' "${ADOC}"
+# Open links in new tab
+sed -i -e '/^\(|https.*\)\(]\)/s//\1^\2/' "${ADOC}"
+# Likewise for footer links
+sed -i -e '/\(\[forked version\)\(]\)/s//\1^\2/' "${ADOC}"
+sed -i -e '/\(\[.*maintainer\)\(]\)/s//\1^\2/' "${ADOC}"
+
+# Adjust `README.adoc`
+ADOC="docs/modules/ROOT/pages/README.adoc"
+# Fix headings throughout file
+sed -i -e '/^=/s///' "${ADOC}"
+# Delete the `[[readme]]` line
+sed -i -e '/^\[\[readme]]$/d' "${ADOC}"
+# Remove the `Table of Contents` line and the blank line after it
+sed -i -e '/^\*Table of Contents\*$/,+1d' "${ADOC}"
+# Fix the link to `CONTRIBUTING.adoc` (to the Antora-based version)
+# shellcheck disable=SC2016
+sed -i -e '/^Please see `How to contribute <CONTRIBUTING>` for more details.$/s//Please see\nxref:main::CONTRIBUTING.adoc[How to contribute]\nfor more details./' "${ADOC}"
+# Fix the link to `CONTRIBUTING.adoc` (to the Antora-based version) -- based on `.github` repo
+sed -i -e '\_https://github.com/saltstack-formulas/.github/blob/master/CONTRIBUTING.rst_s__xref:main::CONTRIBUTING.adoc_' "${ADOC}"
+# Fix the link to `map.jinja.adoc` (to the Antora-based version)
+sed -i -e '/^\* link:map.jinja.rst/s//* xref:main::map.jinja.adoc/' "${ADOC}"
+# Fix link: `#_special_notes`
+sed -i -e '/#special-notes/s//#_special_notes/' "${ADOC}"
+# Fix `sourceCode`
+sed -i -e '/^\(\[source,\)sourceCode,/s//\1/' "${ADOC}"
+# Fix source `jinja2`
+sed -i -e '/^\(\[source,jinja\)2/s//\1/' "${ADOC}"
+# Fix source `sls`
+sed -i -e '/^\(\[source,\)sls/s//\1yaml/' "${ADOC}"
+{%- endif %}

--- a/ssf/files/default/release.config.js
+++ b/ssf/files/default/release.config.js
@@ -15,7 +15,8 @@ module.exports = {
         prepareCmd: 'sh ./pre-commit_semantic-release.sh ${nextRelease.version}',
       }],
       ['@semantic-release/git', {
-        assets: ['*.md', 'docs/*.rst', 'FORMULA'],
+        {#- Temporary hack required until all formulas are converted over to use with Antora #}
+        assets: ['*.md', 'docs/*.rst', 'FORMULA'{{ ", 'docs/antora.yml', 'docs/modules/ROOT/pages/*.adoc'" if semrel_formula in ["apache"] else "" }}],
       }],
       '@semantic-release/github',
   ],

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -368,6 +368,7 @@ ssf_node_anchors:
         pre-commit_semantic-release.sh: &file__pre-commit_semantic-release--sh
           <<: *file_default
           mode: 755
+          template: 'jinja'  # When removing this, also remove the pre-commit exclusion
         release-rules.js: &file__release-rules--js
           <<: *file_default
         release.config.js: &file__release--config--js


### PR DESCRIPTION
Includes a temporary exclusion for the `.pre-commit-config.yaml` template (in the file itself as well), which should be removed when no longer needing to use it as a Jinja template (i.e. when all formulas are configured for Antora).