### PR TITLE
feat(saltimages): update with latest changes from salt-image-builder (3003.3, 3002.7 & 3001.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ tmp/
 # `salt-formula` -- Vagrant Specific files
 .vagrant
 top.sls
+!test/salt/pillar/top.sls
 
 # `suricata-formula` -- Platform binaries
 *.rpm

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -1384,12 +1384,6 @@ ssf:
           2:
             <<: *isk_suite_default
             name: 'v3001-py3'
-          3:
-            <<: *isk_suite_default
-            name: 'v3000-py3'
-          4:
-            <<: *isk_suite_default
-            name: 'v3000-py2'
     sqldeveloper: *formula_default
     sqlplus: *formula_default
     ssf: *formula_default

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -328,10 +328,8 @@ ssf:
     ### `freebsd`
     - [freebsd      ,   13.0 ,   master,      3]  # fbsd-13.0-master-py3
     - [freebsd      ,   12.2 ,   master,      3]  # fbsd-12.2-master-py3
-    - [freebsd      ,   11.4 ,   master,      3]  # fbsd-11.4-master-py3
     - [freebsd      ,   13.0 ,   3003.1,      3]  # fbsd-13.0-3003.1-py3
     - [freebsd      ,   12.2 ,   3003.1,      3]  # fbsd-12.2-3003.1-py3
-    - [freebsd      ,   11.4 ,   3003.1,      3]  # fbsd-11.4-3003.1-py3
     ### `openbsd`
     - [openbsd      ,    6.9 ,   3002.6,      3]  # obsd-06.9-3002.6-py3
     - [openbsd      ,    6.8 ,   3001.1,      3]  # obsd-06.8-3001.1-py3
@@ -341,6 +339,8 @@ ssf:
   vagrantboxes_deprecated:
     ### Deprecated, no longer being built but still available in Vagrant Cloud
     ### `freebsd`
+    - [freebsd      ,   11.4 ,   master,      3]  # fbsd-11.4-master-py3
+    - [freebsd      ,   11.4 ,   3003.1,      3]  # fbsd-11.4-3003.1-py3
     - [freebsd      ,   13.0 ,   3002.6,      3]  # fbsd-13.0-3002.6-py3
     - [freebsd      ,   12.2 ,   3002.6,      3]  # fbsd-12.2-3002.6-py3
     - [freebsd      ,   11.4 ,   3002.6,      3]  # fbsd-11.4-3002.6-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -346,11 +346,12 @@ ssf:
     - [freebsd      ,   11.4 ,   3002.6,      3]  # fbsd-11.4-3002.6-py3
   saltimages_proposed:
     ### Already available but not using across the Formulas' org until released
+    - [debian       ,   12   ,   tiamat,      3]  # debi-12.0-tiamat-py3
     # - [fedora       ,   35   ,   tiamat,      3]  # fedo-35.0-tiamat-py3
     - [fedora       ,   35   ,   master,      3]  # fedo-35.0-master-py3
-    - [fedora       ,   35   ,   3003.2,      3]  # fedo-35.0-3003.2-py3
-    - [fedora       ,   35   ,   3002.6,      3]  # fedo-35.0-3002.6-py3
-    - [fedora       ,   35   ,   3001.7,      3]  # fedo-35.0-3001.7-py3
+    # - [fedora       ,   35   ,   3003.3,      3]  # fedo-35.0-3003.3-py3
+    # - [fedora       ,   35   ,   3002.7,      3]  # fedo-35.0-3002.7-py3
+    # - [fedora       ,   35   ,   3001.8,      3]  # fedo-35.0-3001.8-py3
   saltimages:
     ### `tiamat-py3`
     - [debian       ,   11   ,   tiamat,      3]  # debi-11.0-tiamat-py3
@@ -394,6 +395,82 @@ ssf:
     - [almalinux    ,    8   ,   master,      3]  # alma-08.0-master-py3
     - [rockylinux   ,    8   ,   master,      3]  # rock-08.0-master-py3
 
+    ### `3003.3-py3`
+    - [debian       ,   11   ,   3003.3,      3]  # debi-11.0-3003.3-py3
+    - [debian       ,   10   ,   3003.3,      3]  # debi-10.0-3003.3-py3
+    - [debian       ,    9   ,   3003.3,      3]  # debi-09.0-3003.3-py3
+    - [ubuntu       ,   20.04,   3003.3,      3]  # ubun-20.0-3003.3-py3
+    - [ubuntu       ,   18.04,   3003.3,      3]  # ubun-18.0-3003.3-py3
+    - [centos       ,    8   ,   3003.3,      3]  # cent-08.0-3003.3-py3
+    - [centos       ,    7   ,   3003.3,      3]  # cent-07.0-3003.3-py3
+    - [fedora       ,   34   ,   3003.3,      3]  # fedo-34.0-3003.3-py3
+    - [fedora       ,   33   ,   3003.3,      3]  # fedo-33.0-3003.3-py3
+    - [opensuse/leap,   15.3 ,   3003.3,      3]  # opsu-15.3-3003.3-py3
+    - [opensuse/leap,   15.2 ,   3003.3,      3]  # opsu-15.2-3003.3-py3
+    - [opensuse/tmbl,  latest,   3003.3,      3]  # opsu-tmbl-3003.3-py3
+    - [amazonlinux  ,    2   ,   3003.3,      3]  # amaz-02.0-3003.3-py3
+    - [oraclelinux  ,    8   ,   3003.3,      3]  # orac-08.0-3003.3-py3
+    - [oraclelinux  ,    7   ,   3003.3,      3]  # orac-07.0-3003.3-py3
+    - [arch-base    ,  latest,   3003.3,      3]  # arch-late-3003.3-py3
+    - [gentoo/stage3,  latest,   3003.3,      3]  # gent-late-3003.3-py3
+    - [gentoo/stage3, systemd,   3003.3,      3]  # gent-sysd-3003.3-py3
+    - [almalinux    ,    8   ,   3003.3,      3]  # alma-08.0-3003.3-py3
+
+    ### `3002.7-py3`
+    - [debian       ,   11   ,   3002.7,      3]  # debi-11.0-3002.7-py3
+    - [debian       ,   10   ,   3002.7,      3]  # debi-10.0-3002.7-py3
+    - [debian       ,    9   ,   3002.7,      3]  # debi-09.0-3002.7-py3
+    - [ubuntu       ,   20.04,   3002.7,      3]  # ubun-20.0-3002.7-py3
+    - [ubuntu       ,   18.04,   3002.7,      3]  # ubun-18.0-3002.7-py3
+    - [centos       ,    8   ,   3002.7,      3]  # cent-08.0-3002.7-py3
+    - [centos       ,    7   ,   3002.7,      3]  # cent-07.0-3002.7-py3
+    - [fedora       ,   34   ,   3002.7,      3]  # fedo-34.0-3002.7-py3
+    - [fedora       ,   33   ,   3002.7,      3]  # fedo-33.0-3002.7-py3
+    - [opensuse/leap,   15.3 ,   3002.7,      3]  # opsu-15.3-3002.7-py3
+    - [opensuse/leap,   15.2 ,   3002.7,      3]  # opsu-15.2-3002.7-py3
+    - [opensuse/tmbl,  latest,   3002.7,      3]  # opsu-tmbl-3002.7-py3
+    - [amazonlinux  ,    2   ,   3002.7,      3]  # amaz-02.0-3002.7-py3
+    - [oraclelinux  ,    8   ,   3002.7,      3]  # orac-08.0-3002.7-py3
+    - [oraclelinux  ,    7   ,   3002.7,      3]  # orac-07.0-3002.7-py3
+    - [arch-base    ,  latest,   3002.7,      3]  # arch-late-3002.7-py3
+    - [gentoo/stage3,  latest,   3002.7,      3]  # gent-late-3002.7-py3
+    - [gentoo/stage3, systemd,   3002.7,      3]  # gent-sysd-3002.7-py3
+
+    ### `3001.8-py3`
+    - [debian       ,   10   ,   3001.8,      3]  # debi-10.0-3001.8-py3
+    - [debian       ,    9   ,   3001.8,      3]  # debi-09.0-3001.8-py3
+    - [ubuntu       ,   20.04,   3001.8,      3]  # ubun-20.0-3001.8-py3
+    - [ubuntu       ,   18.04,   3001.8,      3]  # ubun-18.0-3001.8-py3
+    - [centos       ,    8   ,   3001.8,      3]  # cent-08.0-3001.8-py3
+    - [centos       ,    7   ,   3001.8,      3]  # cent-07.0-3001.8-py3
+    - [fedora       ,   34   ,   3001.8,      3]  # fedo-34.0-3001.8-py3
+    - [fedora       ,   33   ,   3001.8,      3]  # fedo-33.0-3001.8-py3
+    - [opensuse/leap,   15.3 ,   3001.8,      3]  # opsu-15.3-3001.8-py3
+    - [opensuse/leap,   15.2 ,   3001.8,      3]  # opsu-15.2-3001.8-py3
+    - [opensuse/tmbl,  latest,   3001.8,      3]  # opsu-tmbl-3001.8-py3
+    - [amazonlinux  ,    2   ,   3001.8,      3]  # amaz-02.0-3001.8-py3
+    - [oraclelinux  ,    8   ,   3001.8,      3]  # orac-08.0-3001.8-py3
+    - [oraclelinux  ,    7   ,   3001.8,      3]  # orac-07.0-3001.8-py3
+    - [arch-base    ,  latest,   3001.8,      3]  # arch-late-3001.8-py3
+    - [gentoo/stage3,  latest,   3001.8,      3]  # gent-late-3001.8-py3
+    - [gentoo/stage3, systemd,   3001.8,      3]  # gent-sysd-3001.8-py3
+
+  # saltimages_deprecated_stable_by_git:
+  #   ### These aren't deprecated per se, since they are the latest `stable` images
+  #   ### available; however, a latest version `git`-based image is available so using
+  #   ### that instead to avoid numerous inconsistencies across the org
+  #   ### Both issues from this formula and in the rendered files such as `kitchen.yml`
+
+  saltimages_deprecated:
+    ### Deprecated, no longer being built but still available in Docker Hub
+    ### `tiamat-py3`
+    - [ubuntu       ,   16.04,   tiamat,      3]  # ubun-16.0-tiamat-py3
+
+    ### `master-py3`
+    - [ubuntu       ,   16.04,   master,      3]  # ubun-16.0-master-py3
+    - [fedora       ,   32   ,   master,      3]  # fedo-32.0-master-py3
+    - [fedora       ,   31   ,   master,      3]  # fedo-31.0-master-py3
+
     ### `3003.2-py3`
     - [debian       ,   11   ,   3003.2,      3]  # debi-11.0-3003.2-py3
     - [debian       ,   10   ,   3003.2,      3]  # debi-10.0-3003.2-py3
@@ -402,6 +479,7 @@ ssf:
     - [ubuntu       ,   18.04,   3003.2,      3]  # ubun-18.0-3003.2-py3
     - [centos       ,    8   ,   3003.2,      3]  # cent-08.0-3003.2-py3
     - [centos       ,    7   ,   3003.2,      3]  # cent-07.0-3003.2-py3
+    # - [fedora       ,   35   ,   3003.2,      3]  # fedo-35.0-3003.2-py3
     - [fedora       ,   34   ,   3003.2,      3]  # fedo-34.0-3003.2-py3
     - [fedora       ,   33   ,   3003.2,      3]  # fedo-33.0-3003.2-py3
     - [opensuse/leap,   15.3 ,   3003.2,      3]  # opsu-15.3-3003.2-py3
@@ -414,97 +492,6 @@ ssf:
     - [gentoo/stage3,  latest,   3003.2,      3]  # gent-late-3003.2-py3
     - [gentoo/stage3, systemd,   3003.2,      3]  # gent-sysd-3003.2-py3
     - [almalinux    ,    8   ,   3003.2,      3]  # alma-08.0-3003.2-py3
-
-    ### `3003.1-py3`
-    ### Add these to `saltimages_deprecated_stable_by_git` once no longer
-    ### needed for the `salt-formula` CI
-    - [arch-base    ,  latest,   3003.1,      3]  # arch-late-3003.1-py3
-    - [gentoo/stage3,  latest,   3003.1,      3]  # gent-late-3003.1-py3
-    - [gentoo/stage3, systemd,   3003.1,      3]  # gent-sysd-3003.1-py3
-
-    ### `3002.6-py3`
-    - [debian       ,   11   ,   3002.6,      3]  # debi-11.0-3002.6-py3
-    - [debian       ,   10   ,   3002.6,      3]  # debi-10.0-3002.6-py3
-    - [debian       ,    9   ,   3002.6,      3]  # debi-09.0-3002.6-py3
-    - [ubuntu       ,   20.04,   3002.6,      3]  # ubun-20.0-3002.6-py3
-    - [ubuntu       ,   18.04,   3002.6,      3]  # ubun-18.0-3002.6-py3
-    - [centos       ,    8   ,   3002.6,      3]  # cent-08.0-3002.6-py3
-    - [centos       ,    7   ,   3002.6,      3]  # cent-07.0-3002.6-py3
-    - [fedora       ,   34   ,   3002.6,      3]  # fedo-34.0-3002.6-py3
-    - [fedora       ,   33   ,   3002.6,      3]  # fedo-33.0-3002.6-py3
-    # - [opensuse/leap,   15.3 ,   3002.6,      3]  # opsu-15.3-3002.6-py3
-    # - [opensuse/leap,   15.2 ,   3002.6,      3]  # opsu-15.2-3002.6-py3
-    # - [opensuse/tmbl,  latest,   3002.6,      3]  # opsu-tmbl-3002.6-py3
-    - [amazonlinux  ,    2   ,   3002.6,      3]  # amaz-02.0-3002.6-py3
-    - [oraclelinux  ,    8   ,   3002.6,      3]  # orac-08.0-3002.6-py3
-    - [oraclelinux  ,    7   ,   3002.6,      3]  # orac-07.0-3002.6-py3
-    - [arch-base    ,  latest,   3002.6,      3]  # arch-late-3002.6-py3
-    - [gentoo/stage3,  latest,   3002.6,      3]  # gent-late-3002.6-py3
-    - [gentoo/stage3, systemd,   3002.6,      3]  # gent-sysd-3002.6-py3
-    ### `3002.2-py3`
-    - [opensuse/leap,   15.3 ,   3002.2,      3]  # opsu-15.3-3002.2-py3
-    - [opensuse/leap,   15.2 ,   3002.2,      3]  # opsu-15.2-3002.2-py3
-    - [opensuse/tmbl,  latest,   3002.2,      3]  # opsu-tmbl-3002.2-py3
-
-    ### `3001.7-py3`
-    - [debian       ,   10   ,   3001.7,      3]  # debi-10.0-3001.7-py3
-    - [debian       ,    9   ,   3001.7,      3]  # debi-09.0-3001.7-py3
-    - [ubuntu       ,   20.04,   3001.7,      3]  # ubun-20.0-3001.7-py3
-    - [ubuntu       ,   18.04,   3001.7,      3]  # ubun-18.0-3001.7-py3
-    - [centos       ,    8   ,   3001.7,      3]  # cent-08.0-3001.7-py3
-    - [centos       ,    7   ,   3001.7,      3]  # cent-07.0-3001.7-py3
-    - [fedora       ,   34   ,   3001.7,      3]  # fedo-34.0-3001.7-py3
-    - [fedora       ,   33   ,   3001.7,      3]  # fedo-33.0-3001.7-py3
-    - [opensuse/leap,   15.3 ,   3001.7,      3]  # opsu-15.3-3001.7-py3
-    - [opensuse/leap,   15.2 ,   3001.7,      3]  # opsu-15.2-3001.7-py3
-    - [opensuse/tmbl,  latest,   3001.7,      3]  # opsu-tmbl-3001.7-py3
-    - [amazonlinux  ,    2   ,   3001.7,      3]  # amaz-02.0-3001.7-py3
-    - [oraclelinux  ,    8   ,   3001.7,      3]  # orac-08.0-3001.7-py3
-    - [oraclelinux  ,    7   ,   3001.7,      3]  # orac-07.0-3001.7-py3
-    - [arch-base    ,  latest,   3001.7,      3]  # arch-late-3001.7-py3
-    - [gentoo/stage3,  latest,   3001.7,      3]  # gent-late-3001.7-py3
-    - [gentoo/stage3, systemd,   3001.7,      3]  # gent-sysd-3001.7-py3
-
-    ### `3000.9-py3`
-    - [debian       ,   10   ,   3000.9,      3]  # debi-10.0-3000.9-py3
-    - [debian       ,    9   ,   3000.9,      3]  # debi-09.0-3000.9-py3
-    - [ubuntu       ,   18.04,   3000.9,      3]  # ubun-18.0-3000.9-py3
-    - [centos       ,    8   ,   3000.9,      3]  # cent-08.0-3000.9-py3
-    - [centos       ,    7   ,   3000.9,      3]  # cent-07.0-3000.9-py3
-    - [opensuse/leap,   15.3 ,   3000.9,      3]  # opsu-15.3-3000.9-py3
-    - [opensuse/leap,   15.2 ,   3000.9,      3]  # opsu-15.2-3000.9-py3
-    - [amazonlinux  ,    2   ,   3000.9,      3]  # amaz-02.0-3000.9-py3
-    - [oraclelinux  ,    8   ,   3000.9,      3]  # orac-08.0-3000.9-py3
-    - [oraclelinux  ,    7   ,   3000.9,      3]  # orac-07.0-3000.9-py3
-    - [gentoo/stage3,  latest,   3000.9,      3]  # gent-late-3000.9-py3
-    - [gentoo/stage3, systemd,   3000.9,      3]  # gent-sysd-3000.9-py3
-    ### `3000.9-py2`
-    - [ubuntu       ,   18.04,   3000.9,      2]  # ubun-18.0-3000.9-py2
-    - [arch-base    ,  latest,   3000.9,      2]  # arch-late-3000.9-py2
-
-  saltimages_deprecated_stable_by_git:
-    ### These aren't deprecated per se, since they are the latest `stable` images
-    ### available; however, a latest version `git`-based image is available so using
-    ### that instead to avoid numerous inconsistencies across the org
-    ### Both issues from this formula and in the rendered files such as `kitchen.yml`
-    ### `3002.5-py3`
-    - [gentoo/stage3,  latest,   3002.5,      3]  # gent-late-3002.5-py3
-    - [gentoo/stage3, systemd,   3002.5,      3]  # gent-sysd-3002.5-py3
-
-    ### `3001.6-py3`
-    - [gentoo/stage3,  latest,   3001.6,      3]  # gent-late-3001.6-py3
-    - [gentoo/stage3, systemd,   3001.6,      3]  # gent-sysd-3001.6-py3
-
-  saltimages_deprecated:
-    ### Deprecated, no longer being built but still available in Docker Hub
-    ### `tiamat-py3`
-    - [ubuntu       ,   16.04,   tiamat,      3]  # ubun-16.0-tiamat-py3
-
-    ### `master-py3`
-    - [ubuntu       ,   16.04,   master,      3]  # ubun-16.0-master-py3
-    - [fedora       ,   32   ,   master,      3]  # fedo-32.0-master-py3
-    - [fedora       ,   31   ,   master,      3]  # fedo-31.0-master-py3
-
     ### `3003.1-py3`
     - [debian       ,   11   ,   3003.1,      3]  # debi-11.0-3003.1-py3
     - [debian       ,   10   ,   3003.1,      3]  # debi-10.0-3003.1-py3
@@ -522,8 +509,10 @@ ssf:
     - [amazonlinux  ,    2   ,   3003.1,      3]  # amaz-02.0-3003.1-py3
     - [oraclelinux  ,    8   ,   3003.1,      3]  # orac-08.0-3003.1-py3
     - [oraclelinux  ,    7   ,   3003.1,      3]  # orac-07.0-3003.1-py3
+    - [arch-base    ,  latest,   3003.1,      3]  # arch-late-3003.1-py3
+    - [gentoo/stage3,  latest,   3003.1,      3]  # gent-late-3003.1-py3
+    - [gentoo/stage3, systemd,   3003.1,      3]  # gent-sysd-3003.1-py3
     - [almalinux    ,    8   ,   3003.1,      3]  # alma-08.0-3003.1-py3
-
     ### `3003.0-py3`
     - [debian       ,   10   ,   3003.0,      3]  # debi-10.0-3003.0-py3
     - [debian       ,    9   ,   3003.0,      3]  # debi-09.0-3003.0-py3
@@ -547,8 +536,27 @@ ssf:
     - [almalinux    ,    8   ,   3003.0,      3]  # alma-08.0-3003.0-py3
 
     ### `3002.6-py3`
+    - [debian       ,   11   ,   3002.6,      3]  # debi-11.0-3002.6-py3
+    - [debian       ,   10   ,   3002.6,      3]  # debi-10.0-3002.6-py3
+    - [debian       ,    9   ,   3002.6,      3]  # debi-09.0-3002.6-py3
+    - [ubuntu       ,   20.04,   3002.6,      3]  # ubun-20.0-3002.6-py3
+    - [ubuntu       ,   18.04,   3002.6,      3]  # ubun-18.0-3002.6-py3
     - [ubuntu       ,   16.04,   3002.6,      3]  # ubun-16.0-3002.6-py3
+    - [centos       ,    8   ,   3002.6,      3]  # cent-08.0-3002.6-py3
+    - [centos       ,    7   ,   3002.6,      3]  # cent-07.0-3002.6-py3
+    - [fedora       ,   35   ,   3002.6,      3]  # fedo-35.0-3002.6-py3
+    - [fedora       ,   34   ,   3002.6,      3]  # fedo-34.0-3002.6-py3
+    - [fedora       ,   33   ,   3002.6,      3]  # fedo-33.0-3002.6-py3
     - [fedora       ,   32   ,   3002.6,      3]  # fedo-32.0-3002.6-py3
+    # - [opensuse/leap,   15.3 ,   3002.6,      3]  # opsu-15.3-3002.6-py3
+    # - [opensuse/leap,   15.2 ,   3002.6,      3]  # opsu-15.2-3002.6-py3
+    # - [opensuse/tmbl,  latest,   3002.6,      3]  # opsu-tmbl-3002.6-py3
+    - [amazonlinux  ,    2   ,   3002.6,      3]  # amaz-02.0-3002.6-py3
+    - [oraclelinux  ,    8   ,   3002.6,      3]  # orac-08.0-3002.6-py3
+    - [oraclelinux  ,    7   ,   3002.6,      3]  # orac-07.0-3002.6-py3
+    - [arch-base    ,  latest,   3002.6,      3]  # arch-late-3002.6-py3
+    - [gentoo/stage3,  latest,   3002.6,      3]  # gent-late-3002.6-py3
+    - [gentoo/stage3, systemd,   3002.6,      3]  # gent-sysd-3002.6-py3
     ### `3002.5-py3`
     - [debian       ,   10   ,   3002.5,      3]  # debi-10.0-3002.5-py3
     - [debian       ,    9   ,   3002.5,      3]  # debi-09.0-3002.5-py3
@@ -565,6 +573,8 @@ ssf:
     - [amazonlinux  ,    2   ,   3002.5,      3]  # amaz-02.0-3002.5-py3
     - [oraclelinux  ,    8   ,   3002.5,      3]  # orac-08.0-3002.5-py3
     - [oraclelinux  ,    7   ,   3002.5,      3]  # orac-07.0-3002.5-py3
+    - [gentoo/stage3,  latest,   3002.5,      3]  # gent-late-3002.5-py3
+    - [gentoo/stage3, systemd,   3002.5,      3]  # gent-sysd-3002.5-py3
     - [arch-base    ,  latest,   3002.5,      3]  # arch-late-3002.5-py3
     ### `3002.2-py3`
     - [debian       ,   10   ,   3002.2,      3]  # debi-10.0-3002.2-py3
@@ -576,8 +586,9 @@ ssf:
     - [centos       ,    7   ,   3002.2,      3]  # cent-07.0-3002.2-py3
     - [fedora       ,   33   ,   3002.2,      3]  # fedo-33.0-3002.2-py3
     - [fedora       ,   32   ,   3002.2,      3]  # fedo-32.0-3002.2-py3
-    # - [opensuse/leap,   15.2 ,   3002.2,      3]  # opsu-15.2-3002.2-py3
-    # - [opensuse/tmbl,  latest,   3002.2,      3]  # opsu-tmbl-3002.2-py3
+    - [opensuse/leap,   15.3 ,   3002.2,      3]  # opsu-15.3-3002.2-py3
+    - [opensuse/leap,   15.2 ,   3002.2,      3]  # opsu-15.2-3002.2-py3
+    - [opensuse/tmbl,  latest,   3002.2,      3]  # opsu-tmbl-3002.2-py3
     - [amazonlinux  ,    2   ,   3002.2,      3]  # amaz-02.0-3002.2-py3
     - [oraclelinux  ,    8   ,   3002.2,      3]  # orac-08.0-3002.2-py3
     - [oraclelinux  ,    7   ,   3002.2,      3]  # orac-07.0-3002.2-py3
@@ -623,8 +634,26 @@ ssf:
     - [gentoo/stage3, systemd,   3002.0,      3]  # gent-sysd-3002.0-py3
 
     ### `3001.7-py3`
+    - [debian       ,   10   ,   3001.7,      3]  # debi-10.0-3001.7-py3
+    - [debian       ,    9   ,   3001.7,      3]  # debi-09.0-3001.7-py3
+    - [ubuntu       ,   20.04,   3001.7,      3]  # ubun-20.0-3001.7-py3
+    - [ubuntu       ,   18.04,   3001.7,      3]  # ubun-18.0-3001.7-py3
     - [ubuntu       ,   16.04,   3001.7,      3]  # ubun-16.0-3001.7-py3
+    - [centos       ,    8   ,   3001.7,      3]  # cent-08.0-3001.7-py3
+    - [centos       ,    7   ,   3001.7,      3]  # cent-07.0-3001.7-py3
+    - [fedora       ,   35   ,   3001.7,      3]  # fedo-35.0-3001.7-py3
+    - [fedora       ,   34   ,   3001.7,      3]  # fedo-34.0-3001.7-py3
+    - [fedora       ,   33   ,   3001.7,      3]  # fedo-33.0-3001.7-py3
     - [fedora       ,   32   ,   3001.7,      3]  # fedo-32.0-3001.7-py3
+    - [opensuse/leap,   15.3 ,   3001.7,      3]  # opsu-15.3-3001.7-py3
+    - [opensuse/leap,   15.2 ,   3001.7,      3]  # opsu-15.2-3001.7-py3
+    - [opensuse/tmbl,  latest,   3001.7,      3]  # opsu-tmbl-3001.7-py3
+    - [amazonlinux  ,    2   ,   3001.7,      3]  # amaz-02.0-3001.7-py3
+    - [oraclelinux  ,    8   ,   3001.7,      3]  # orac-08.0-3001.7-py3
+    - [oraclelinux  ,    7   ,   3001.7,      3]  # orac-07.0-3001.7-py3
+    - [arch-base    ,  latest,   3001.7,      3]  # arch-late-3001.7-py3
+    - [gentoo/stage3,  latest,   3001.7,      3]  # gent-late-3001.7-py3
+    - [gentoo/stage3, systemd,   3001.7,      3]  # gent-sysd-3001.7-py3
     ### `3001.6-py3`
     - [debian       ,   10   ,   3001.6,      3]  # debi-10.0-3001.6-py3
     - [debian       ,    9   ,   3001.6,      3]  # debi-09.0-3001.6-py3
@@ -642,6 +671,8 @@ ssf:
     - [oraclelinux  ,    8   ,   3001.6,      3]  # orac-08.0-3001.6-py3
     - [oraclelinux  ,    7   ,   3001.6,      3]  # orac-07.0-3001.6-py3
     - [arch-base    ,  latest,   3001.6,      3]  # arch-late-3001.6-py3
+    - [gentoo/stage3,  latest,   3001.6,      3]  # gent-late-3001.6-py3
+    - [gentoo/stage3, systemd,   3001.6,      3]  # gent-sysd-3001.6-py3
     ### `3001.4-py3`
     - [debian       ,   10   ,   3001.4,      3]  # debi-10.0-3001.4-py3
     - [debian       ,    9   ,   3001.4,      3]  # debi-09.0-3001.4-py3
@@ -718,9 +749,23 @@ ssf:
     - [gentoo/stage3, systemd,   3001  ,      3]  # gent-sysd-3001.0-py3
 
     ### `3000.9-py3`
+    - [debian       ,   10   ,   3000.9,      3]  # debi-10.0-3000.9-py3
+    - [debian       ,    9   ,   3000.9,      3]  # debi-09.0-3000.9-py3
+    - [ubuntu       ,   18.04,   3000.9,      3]  # ubun-18.0-3000.9-py3
     - [ubuntu       ,   16.04,   3000.9,      3]  # ubun-16.0-3000.9-py3
+    - [centos       ,    8   ,   3000.9,      3]  # cent-08.0-3000.9-py3
+    - [centos       ,    7   ,   3000.9,      3]  # cent-07.0-3000.9-py3
+    - [opensuse/leap,   15.3 ,   3000.9,      3]  # opsu-15.3-3000.9-py3
+    - [opensuse/leap,   15.2 ,   3000.9,      3]  # opsu-15.2-3000.9-py3
+    - [amazonlinux  ,    2   ,   3000.9,      3]  # amaz-02.0-3000.9-py3
+    - [oraclelinux  ,    8   ,   3000.9,      3]  # orac-08.0-3000.9-py3
+    - [oraclelinux  ,    7   ,   3000.9,      3]  # orac-07.0-3000.9-py3
+    - [gentoo/stage3,  latest,   3000.9,      3]  # gent-late-3000.9-py3
+    - [gentoo/stage3, systemd,   3000.9,      3]  # gent-sysd-3000.9-py3
     ### `3000.9-py2`
+    - [ubuntu       ,   18.04,   3000.9,      2]  # ubun-18.0-3000.9-py2
     - [ubuntu       ,   16.04,   3000.9,      2]  # ubun-16.0-3000.9-py2
+    - [arch-base    ,  latest,   3000.9,      2]  # arch-late-3000.9-py2
     ### `3000.8-py3`
     - [debian       ,   10   ,   3000.8,      3]  # debi-10.0-3000.8-py3
     - [debian       ,    9   ,   3000.8,      3]  # debi-09.0-3000.8-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "test(map): verify '`'map.jinja'`' dump using '`'_mapdata'`' state"
-            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/371'
+            title: "ci(kitchen+ci): update with latest CVE pre-salted images"
+            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/374'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/.gitignore
+++ b/ssf/files/default/.gitignore
@@ -127,6 +127,7 @@ tmp/
 # `salt-formula` -- Vagrant Specific files
 .vagrant
 top.sls
+!test/salt/pillar/top.sls
 
 # `suricata-formula` -- Platform binaries
 *.rpm

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -4267,8 +4267,8 @@ ssf:
           0:
             includes:
               # [os           ,  os_ver, salt_ver, py_ver]
-              - [0            ,    0   ,   3003.2,      3]
-              - [0            ,    0   ,   3003.1,      3]
+              - [0            ,    0   ,   3003.3,      3]
+              - [freebsd      ,    0   ,   3003.1,      3]
               - [windows      ,    0   ,   latest,      3]
             inspec_yml:
               summary: >-
@@ -4285,8 +4285,19 @@ ssf:
           1:
             includes:
               # [os           ,  os_ver, salt_ver, py_ver]
-              - [0            ,    0   ,   3002.6,      3]
-              - [0            ,    0   ,   3002.2,      3]
+              - [debian       ,    0   ,   3002.7,      3]
+              - [ubuntu       ,    0   ,   3002.7,      3]
+              - [centos       ,    0   ,   3002.7,      3]
+              # - [fedora       ,    0   ,   3002.7,      3]
+              # - [opensuse/leap,    0   ,   3002.7,      3]
+              # - [opensuse/tmbl,    0   ,   3002.7,      3]
+              - [amazonlinux  ,    0   ,   3002.7,      3]
+              - [oraclelinux  ,    0   ,   3002.7,      3]
+              # - [arch-base    ,    0   ,   3002.7,      3]
+              - [gentoo/stage3,    0   ,   3002.7,      3]
+              - [almalinux    ,    0   ,   3002.7,      3]
+              - [rockylinux   ,    0   ,   3002.7,      3]
+              - [openbsd      ,    0   ,   3002.6,      3]
             inspec_yml:
               summary: >-
                 Verify that Salt `v3002-py3` is setup and configured
@@ -4302,7 +4313,18 @@ ssf:
           2:
             includes:
               # [os           ,  os_ver, salt_ver, py_ver]
-              - [0            ,    0   ,   3001.7,      3]
+              - [debian       ,    0   ,   3001.8,      3]
+              - [ubuntu       ,    0   ,   3001.8,      3]
+              - [centos       ,    0   ,   3001.8,      3]
+              # - [fedora       ,    0   ,   3001.8,      3]
+              # - [opensuse/leap,    0   ,   3001.8,      3]
+              # - [opensuse/tmbl,    0   ,   3001.8,      3]
+              - [amazonlinux  ,    0   ,   3001.8,      3]
+              - [oraclelinux  ,    0   ,   3001.8,      3]
+              # - [arch-base    ,    0   ,   3001.8,      3]
+              # - [gentoo/stage3,    0   ,   3001.8,      3]
+              - [almalinux    ,    0   ,   3001.8,      3]
+              - [rockylinux   ,    0   ,   3001.8,      3]
               - [openbsd      ,    0   ,   3001.1,      3]
             inspec_yml:
               summary: >-
@@ -4316,150 +4338,83 @@ ssf:
                 - .sls: 'test/salt/pillar/salt.sls'
                 - v3001-py3.sls: 'test/salt/pillar/v3001-py3.sls'
               state_top: *state_top_salt
-          3:
-            includes:
-              # [os           ,  os_ver, salt_ver, py_ver]
-              - [0            ,    0   ,   3000.9,      3]
-            inspec_yml:
-              summary: >-
-                Verify that Salt `v3000-py3` is setup and configured
-            provisioner:
-              pillars:
-                - '*':
-                    - .
-                    - v3000-py3
-              pillars_from_files:
-                - .sls: 'test/salt/pillar/salt.sls'
-                - v3000-py3.sls: 'test/salt/pillar/v3000-py3.sls'
-              state_top: *state_top_salt
-          4:
-            includes:
-              # [os           ,  os_ver, salt_ver, py_ver]
-              - [0            ,    0   ,   3000.9,      2]
-            inspec_yml:
-              summary: >-
-                Verify that Salt `v3000-py2` is setup and configured
-            provisioner:
-              pillars:
-                - '*':
-                    - .
-                    - v3000-py2
-              pillars_from_files:
-                - .sls: 'test/salt/pillar/salt.sls'
-                - v3000-py2.sls: 'test/salt/pillar/v3000-py2.sls'
-              state_top: *state_top_salt
         inspec_suites_matrix:
           - v3003-py3
           - v3002-py3
           - v3001-py3
-          - v3000-py3
-          - v3000-py2
         map_jinja:
           verification:
             import: ['salt_settings', 'formulas_settings']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           ### `v3003-py3`
-          - [debian       ,   11   ,   3003.2,      3,       v3003-py3]
-          # - [debian       ,   10   ,   3003.2,      3,       v3003-py3]
-          # - [debian       ,    9   ,   3003.2,      3,       v3003-py3]
-          - [ubuntu       ,   20.04,   3003.2,      3,       v3003-py3]
-          # - [ubuntu       ,   18.04,   3003.2,      3,       v3003-py3]
-          - [centos       ,    8   ,   3003.2,      3,       v3003-py3]
-          # - [centos       ,    7   ,   3003.2,      3,       v3003-py3]
-          # # Unavailable below since only installs `3003.X`
-          - [fedora       ,   34   ,   3003.2,      3,       v3003-py3]
-          - [fedora       ,   33   ,   3003.2,      3,       v3003-py3]
-          # # TODO: Fix when `3003.2` released; however, see the note below about
-          # #       using either `15.3` or `15.2` due to a shared `_mapdata`
-          # #       verification file within the same InSpec suite
-          # # - [opensuse/leap,   15.3 ,   3003.2,      3,       v3003-py3]
-          # # - [opensuse/leap,   15.2 ,   3003.2,      3,       v3003-py3]
-          # # - [opensuse/tmbl,  latest,   3003.2,      3,       v3003-py3]
-          - [amazonlinux  ,    2   ,   3003.2,      3,       v3003-py3]
-          - [oraclelinux  ,    8   ,   3003.2,      3,       v3003-py3]
-          # - [oraclelinux  ,    7   ,   3003.2,      3,       v3003-py3]
-          # # TODO: Fix when `3003.2` released
-          # - [arch-base    ,  latest,   3003.2,      3,       v3003-py3]
-          - [arch-base    ,  latest,   3003.1,      3,       v3003-py3]
-          # # TODO: Fix when `3003.2` released
-          # - [gentoo/stage3,  latest,   3003.2,      3,       v3003-py3]
-          # - [gentoo/stage3, systemd,   3003.2,      3,       v3003-py3]
-          - [gentoo/stage3,  latest,   3003.1,      3,       v3003-py3]
-          - [gentoo/stage3, systemd,   3003.1,      3,       v3003-py3]
-          - [almalinux    ,    8   ,   3003.2,      3,       v3003-py3]
+          - [debian       ,   11   ,   3003.3,      3,       v3003-py3]
+          # - [debian       ,   10   ,   3003.3,      3,       v3003-py3]
+          # - [debian       ,    9   ,   3003.3,      3,       v3003-py3]
+          - [ubuntu       ,   20.04,   3003.3,      3,       v3003-py3]
+          # - [ubuntu       ,   18.04,   3003.3,      3,       v3003-py3]
+          - [centos       ,    8   ,   3003.3,      3,       v3003-py3]
+          # - [centos       ,    7   ,   3003.3,      3,       v3003-py3]
+          # # `fedora` unavailable below since only installs `3003.X`
+          - [fedora       ,   34   ,   3003.3,      3,       v3003-py3]
+          - [fedora       ,   33   ,   3003.3,      3,       v3003-py3]
+          # # `opensuse/*` unavailable below since only installs `3003.X`
+          # # Can't use both `15.3` & `15.2` together within the same
+          # # InSpec suite when there's a shared `_mapdata` verification file --
+          # # using the currently supported version for now (re: Salt repo)
+          - [opensuse/leap,   15.3 ,   3003.3,      3,       v3003-py3]
+          # - [opensuse/leap,   15.2 ,   3003.3,      3,       v3003-py3]
+          # # Was last working properly with `3002.2`, hitting a problem with `3003.3`:
+          # # `'service' __virtual__ returned False: No service execution module loaded`
+          # # Actually still works if running `kitchen converge` a second time;
+          # # thought it might work with the `retry_options` used for FreeBSD
+          # # but it didn't -- disabling for the time being
+          # - [opensuse/tmbl,  latest,   3003.3,      3,       v3003-py3]
+          - [amazonlinux  ,    2   ,   3003.3,      3,       v3003-py3]
+          - [oraclelinux  ,    8   ,   3003.3,      3,       v3003-py3]
+          # - [oraclelinux  ,    7   ,   3003.3,      3,       v3003-py3]
+          # # `arch` unavailable below since only installs `3003.X`
+          - [arch-base    ,  latest,   3003.3,      3,       v3003-py3]
+          - [gentoo/stage3,  latest,   3003.3,      3,       v3003-py3]
+          - [gentoo/stage3, systemd,   3003.3,      3,       v3003-py3]
+          - [almalinux    ,    8   ,   3003.3,      3,       v3003-py3]
           # # TODO: When supported in an official release, move this platform
           # #       to that release (as a minimum, no other Salt versions)
-          - [rockylinux   ,    0   ,   3003.2,      3,       v3003-py3]
+          - [rockylinux   ,    0   ,   3003.3,      3,       v3003-py3]
           # # FreeBSD and Windows won't always be in sync with the Linux
           # # platforms above
           - [freebsd      ,    0   ,   3003.1,      3,       v3003-py3]
           - [windows      ,    0   ,   latest,      3,       v3003-py3]
 
           ### `v3002-py3`
-          # - [debian       ,   11   ,   3002.6,      3,       v3002-py3]
-          - [debian       ,   10   ,   3002.6,      3,       v3002-py3]
-          # - [debian       ,    9   ,   3002.6,      3,       v3002-py3]
-          - [ubuntu       ,   20.04,   3002.6,      3,       v3002-py3]
-          # - [ubuntu       ,   18.04,   3002.6,      3,       v3002-py3]
-          # - [centos       ,    8   ,   3002.6,      3,       v3002-py3]
-          - [centos       ,    7   ,   3002.6,      3,       v3002-py3]
-          # # Note, `3002.2` is the last in this series for openSUSE
-          # # Furthermore, can't use both `15.3` & `15.2` together within the same
-          # # InSpec suite when there's a shared `_mapdata` verification file --
-          # # using the currently supported version for now (re: Salt repo)
-          # - [opensuse/leap,   15.3 ,   3002.2,      3,       v3002-py3]
-          - [opensuse/leap,   15.2 ,   3002.2,      3,       v3002-py3]
-          - [opensuse/tmbl,  latest,   3002.2,      3,       v3002-py3]
-          - [amazonlinux  ,    2   ,   3002.6,      3,       v3002-py3]
-          # - [oraclelinux  ,    8   ,   3002.6,      3,       v3002-py3]
-          - [oraclelinux  ,    7   ,   3002.6,      3,       v3002-py3]
-          # # - [arch-base    ,  latest,   3002.6,      3,       v3002-py3]
-          # - [gentoo/stage3,  latest,   3002.6,      3,       v3002-py3]
-          # - [gentoo/stage3, systemd,   3002.6,      3,       v3002-py3]
+          # - [debian       ,   11   ,   3002.7,      3,       v3002-py3]
+          - [debian       ,   10   ,   3002.7,      3,       v3002-py3]
+          # - [debian       ,    9   ,   3002.7,      3,       v3002-py3]
+          - [ubuntu       ,   20.04,   3002.7,      3,       v3002-py3]
+          # - [ubuntu       ,   18.04,   3002.7,      3,       v3002-py3]
+          - [centos       ,    8   ,   3002.7,      3,       v3002-py3]
+          # - [centos       ,    7   ,   3002.7,      3,       v3002-py3]
+          # - [amazonlinux  ,    2   ,   3002.7,      3,       v3002-py3]
+          - [oraclelinux  ,    8   ,   3002.7,      3,       v3002-py3]
+          # - [oraclelinux  ,    7   ,   3002.7,      3,       v3002-py3]
+          # - [gentoo/stage3,  latest,   3002.7,      3,       v3002-py3]
+          # - [gentoo/stage3, systemd,   3002.7,      3,       v3002-py3]
           - [openbsd      ,    0   ,   3002.6,      3,       v3002-py3]
 
           ### `v3001-py3`
-          # - [debian       ,   11   ,   3001.7,      3,       v3001-py3]
-          - [debian       ,   10   ,   3001.7,      3,       v3001-py3]
-          # - [debian       ,    9   ,   3001.7,      3,       v3001-py3]
-          - [ubuntu       ,   20.04,   3001.7,      3,       v3001-py3]
-          # - [ubuntu       ,   18.04,   3001.7,      3,       v3001-py3]
-          - [centos       ,    8   ,   3001.7,      3,       v3001-py3]
-          # - [centos       ,    7   ,   3001.7,      3,       v3001-py3]
-          # # Installs `3002.X`
-          # # - [opensuse/leap,   15.3 ,   3001.7,      3,       v3001-py3]
-          # # - [opensuse/leap,   15.2 ,   3001.7,      3,       v3001-py3]
-          # # - [opensuse/tmbl,  latest,   3001.7,      3,       v3001-py3]
-          # - [amazonlinux  ,    2   ,   3001.7,      3,       v3001-py3]
-          - [oraclelinux  ,    8   ,   3001.7,      3,       v3001-py3]
-          # - [oraclelinux  ,    7   ,   3001.7,      3,       v3001-py3]
-          # # - [arch-base    ,  latest,   3001.7,      3,       v3001-py3]
-          # - [gentoo/stage3,  latest,   3001.7,      3,       v3001-py3]
-          # - [gentoo/stage3, systemd,   3001.7,      3,       v3001-py3]
+          # - [debian       ,   10   ,   3001.8,      3,       v3001-py3]
+          - [debian       ,    9   ,   3001.8,      3,       v3001-py3]
+          # - [ubuntu       ,   20.04,   3001.8,      3,       v3001-py3]
+          - [ubuntu       ,   18.04,   3001.8,      3,       v3001-py3]
+          # - [centos       ,    8   ,   3001.8,      3,       v3001-py3]
+          - [centos       ,    7   ,   3001.8,      3,       v3001-py3]
+          # - [amazonlinux  ,    2   ,   3001.8,      3,       v3001-py3]
+          # - [oraclelinux  ,    8   ,   3001.8,      3,       v3001-py3]
+          - [oraclelinux  ,    7   ,   3001.8,      3,       v3001-py3]
           - [openbsd      ,    0   ,   3001.1,      3,       v3001-py3]
-
-          ### `v3000-py3`
-          # - [debian       ,   11   ,   3000.9,      3,       v3000-py3]
-          # - [debian       ,   10   ,   3000.9,      3,       v3000-py3]
-          - [debian       ,    9   ,   3000.9,      3,       v3000-py3]
-          - [ubuntu       ,   18.04,   3000.9,      3,       v3000-py3]
-          # - [centos       ,    8   ,   3000.9,      3,       v3000-py3]
-          - [centos       ,    7   ,   3000.9,      3,       v3000-py3]
-          # # Installs `3002.X`
-          # # - [opensuse/leap,   15.3 ,   3000.9,      3,       v3000-py3]
-          # # - [opensuse/leap,   15.2 ,   3000.9,      3,       v3000-py3]
-          # - [amazonlinux  ,    2   ,   3000.9,      3,       v3000-py3]
-          # - [oraclelinux  ,    8   ,   3000.9,      3,       v3000-py3]
-          - [oraclelinux  ,    7   ,   3000.9,      3,       v3000-py3]
-          # - [gentoo/stage3,  latest,   3000.9,      3,       v3000-py3]
-          # - [gentoo/stage3, systemd,   3000.9,      3,       v3000-py3]
-
-          ### `v3000-py2`
-          - [ubuntu       ,   18.04,   3000.9,      2,       v3000-py2]
-          # # - [arch-base    ,  latest,   3000.9,      2,       v3000-py2]
         platforms_matrix_allow_failure:
-          - [debian       ,   11   ,   3003.2,      3,       v3003-py3]
+          - [debian       ,   11   ,   3003.3,      3,       v3003-py3]
+          - [debian       ,   11   ,   3002.7,      3,       v3002-py3]
         testing_freebsd:
           active: true
         testing_openbsd:
@@ -4469,7 +4424,7 @@ ssf:
           github:
             platforms:
               provisioner:
-                salt_bootstrap_options: '-pythonVersion 3 -version 3003.2'
+                salt_bootstrap_options: '-pythonVersion 3 -version 3003.3'
           winrepo_ng: ['salt-minion-py3']
         use_tofs: true
         yamllint:


### PR DESCRIPTION
Also includes:

* feat(freebsd): deprecate `11.4` (EOL: 2021-09-30)
* feat(gitignore): allow test pillar `top.sls` (`template-formula` PR)
  - https://github.com/saltstack-formulas/template-formula/pull/238