### PR TITLE
feat(formulas): add basic management for `Gemfile+lock` formulas

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -75,7 +75,9 @@ ssf:
   ### State the formulas and files to work through when running the formula
   active:
     semrel_formulas:
+      - ad
       - aegir
+      - airflow
       - apache
       - apt
       - apt-cacher
@@ -137,6 +139,7 @@ ssf:
       - nginx
       - nifi
       - node
+      - nsd
       - ntp
       - nut
       - openldap
@@ -144,6 +147,7 @@ ssf:
       - openssh
       - openvpn
       - packages
+      - pam-mount
       - php
       - postfix
       - postgres
@@ -159,6 +163,7 @@ ssf:
       - rstudio
       - rundeck
       - salt
+      - splunkforwarder
       - sqldeveloper
       - sqlplus
       - ssf
@@ -173,9 +178,11 @@ ssf:
       - systemd
       - telegraf
       - template
+      - test
       - timezone
       - tomcat
       - ufw
+      - unbound
       - users
       - varnish
       - vault

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -65,7 +65,7 @@ ssf_node_anchors:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
             title: "chore(gemfile.lock): update to latest gem versions (2021-W40) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/375'
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/376'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'
@@ -859,7 +859,9 @@ ssf:
 
   semrel_formulas:
     .github: *formula_default
+    ad: *formula_default
     aegir: *formula_default
+    airflow: *formula_default
     apache:
       <<: *formula_default
       context:
@@ -1215,6 +1217,7 @@ ssf:
           3:
             <<: *isk_suite_default
             name: 'repo'
+    nsd: *formula_default
     ntp: *formula_default
     nut:
       <<: *formula_default
@@ -1268,6 +1271,7 @@ ssf:
           10:
             <<: *isk_suite_default
             name: 'windows'
+    pam-mount: *formula_default
     php:
       <<: *formula_default
       context:
@@ -1384,6 +1388,7 @@ ssf:
           2:
             <<: *isk_suite_default
             name: 'v3001-py3'
+    splunkforwarder: *formula_default
     sqldeveloper: *formula_default
     sqlplus: *formula_default
     ssf: *formula_default
@@ -1416,6 +1421,7 @@ ssf:
           1:
             <<: *isk_suite_default
             name: 'gentoo'
+    test: *formula_default
     timezone: *formula_default
     tomcat: *formula_default
     ufw:
@@ -1427,6 +1433,7 @@ ssf:
           1:
             <<: *isk_suite_default
             name: 'without-ipv6'
+    unbound: *formula_default
     users:
       <<: *formula_default
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -403,6 +403,20 @@ ssf:
         docs/CONTRIBUTING.rst:
           <<: *file__docs__CONTRIBUTING--rst
           dest_file: 'CONTRIBUTING.rst'
+    ad:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@baby-gnu'
+        git:
+          github:
+            repo: 'ad-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     aegir:
       context:
         codeowners:
@@ -412,6 +426,20 @@ ssf:
         git:
           github:
             repo: 'aegir-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
+    airflow:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@noelmcloughlin'
+        git:
+          github:
+            repo: 'airflow-formula'
         inspec_suites_kitchen: {}
         inspec_suites_matrix: []
         platforms: []
@@ -3086,6 +3114,20 @@ ssf:
             additional:
               - node/osfamilymap.yaml
       semrel_files: *semrel_files_default
+    nsd:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@alxwr'
+        git:
+          github:
+            repo: 'nsd-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     ntp:
       context:
         git:
@@ -3547,6 +3589,20 @@ ssf:
         testing_windows:
           active: true
       semrel_files: *semrel_files_inc_map_jinja_verifier
+    pam-mount:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@baby-gnu'
+        git:
+          github:
+            repo: 'pam-mount-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     php:
       context:
         codeowners:
@@ -4434,6 +4490,20 @@ ssf:
               - salt/osmap.yaml
               - salt/osfingermap.yaml
       semrel_files: *semrel_files_inc_map_jinja_verifier
+    splunkforwarder:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@codeboyQ2n5ha45'
+        git:
+          github:
+            repo: 'splunkforwarder-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     sqldeveloper:
       context:
         codeowners:
@@ -4968,6 +5038,20 @@ ssf:
         inspec/controls/_mapdata.rb:
           <<: *file__inspec__controls___mapdata--rb
           alt_semrel_formula: 'TEMPLATE'
+    test:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@myii'
+        git:
+          github:
+            repo: 'test-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     timezone:
       context:
         git:
@@ -5091,6 +5175,20 @@ ssf:
           - [rockylinux   ,    0   ,   master,      0,         default]
         use_tofs: true
       semrel_files: *semrel_files_default
+    unbound:
+      context:
+        codeowners:
+          entries:
+            global:
+              - '*': '@alxwr'
+        git:
+          github:
+            repo: 'unbound-formula'
+        inspec_suites_kitchen: {}
+        inspec_suites_matrix: []
+        platforms: []
+        platforms_matrix: []
+      semrel_files: *semrel_files_mainly_gemfiles_only
     users:
       context:
         git:


### PR DESCRIPTION
Encountered some more formulas that have a `Gemfile.lock`.
Again, ideally, they should be managed like the rest of the
formulas but implementing a basic solution for the `Gemfile` and
`Gemfile.lock` files right now.  Also includes management of the
`commitlint` GitHub Action as well as the `CODEOWNERS` file.

* ad-formula
* airflow-formula
* nsd-formula
* pam-mount-formula
* splunkforwarder-formula
* test-formula
  - While this isn't a "proper" formula, it is useful to have around for
    testing new features using this `ssf-formula`.
* unbound-formula