### PR TITLE
feat: use latest pre-salted images for all formulas (inc. `3004`)

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -349,7 +349,6 @@ ssf:
     - [freebsd      ,   12.2 ,   3003.1,      3]  # fbsd-12.2-3003.1-py3
     ### `openbsd`
     - [openbsd      ,    6.9 ,   3002.6,      3]  # obsd-06.9-3002.6-py3
-    - [openbsd      ,    6.8 ,   3001.1,      3]  # obsd-06.8-3001.1-py3
     ### `windows`
     - [windows      ,   10   ,   latest,      3]  # wind-10.0-latest-py3
     - [windows      ,    8.1 ,   latest,      3]  # wind-08.1-latest-py3
@@ -361,6 +360,8 @@ ssf:
     - [freebsd      ,   13.0 ,   3002.6,      3]  # fbsd-13.0-3002.6-py3
     - [freebsd      ,   12.2 ,   3002.6,      3]  # fbsd-12.2-3002.6-py3
     - [freebsd      ,   11.4 ,   3002.6,      3]  # fbsd-11.4-3002.6-py3
+    ### `openbsd`
+    - [openbsd      ,    6.8 ,   3001.1,      3]  # obsd-06.8-3001.1-py3
   saltimages_proposed:
     ### Already available but not using across the Formulas' org until released
     ### Or not currently being built successfully due to Docker issues

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -363,9 +363,11 @@ ssf:
     - [freebsd      ,   11.4 ,   3002.6,      3]  # fbsd-11.4-3002.6-py3
   saltimages_proposed:
     ### Already available but not using across the Formulas' org until released
+    ### Or not currently being built successfully due to Docker issues
     - [debian       ,   12   ,   tiamat,      3]  # debi-12.0-tiamat-py3
     # - [fedora       ,   35   ,   tiamat,      3]  # fedo-35.0-tiamat-py3
     - [fedora       ,   35   ,   master,      3]  # fedo-35.0-master-py3
+    # - [fedora       ,   35   ,   3004.0,      3]  # fedo-35.0-3004.0-py3
     # - [fedora       ,   35   ,   3003.3,      3]  # fedo-35.0-3003.3-py3
     # - [fedora       ,   35   ,   3002.7,      3]  # fedo-35.0-3002.7-py3
     # - [fedora       ,   35   ,   3001.8,      3]  # fedo-35.0-3001.8-py3
@@ -413,6 +415,29 @@ ssf:
     - [gentoo/stage3, systemd,   master,      3]  # gent-sysd-master-py3
     - [almalinux    ,    8   ,   master,      3]  # alma-08.0-master-py3
     - [rockylinux   ,    8   ,   master,      3]  # rock-08.0-master-py3
+
+    ### `3004.0-py3`
+    - [debian       ,   11   ,   3004.0,      3]  # debi-11.0-3004.0-py3
+    - [debian       ,   10   ,   3004.0,      3]  # debi-10.0-3004.0-py3
+    - [debian       ,    9   ,   3004.0,      3]  # debi-09.0-3004.0-py3
+    - [ubuntu       ,   20.04,   3004.0,      3]  # ubun-20.0-3004.0-py3
+    - [ubuntu       ,   18.04,   3004.0,      3]  # ubun-18.0-3004.0-py3
+    - [centos       , stream8,   3004.0,      3]  # cstr-08.0-3004.0-py3
+    - [centos       ,    8   ,   3004.0,      3]  # cent-08.0-3004.0-py3
+    - [centos       ,    7   ,   3004.0,      3]  # cent-07.0-3004.0-py3
+    - [fedora       ,   34   ,   3004.0,      3]  # fedo-34.0-3004.0-py3
+    - [fedora       ,   33   ,   3004.0,      3]  # fedo-33.0-3004.0-py3
+    - [opensuse/leap,   15.3 ,   3004.0,      3]  # opsu-15.3-3004.0-py3
+    - [opensuse/leap,   15.2 ,   3004.0,      3]  # opsu-15.2-3004.0-py3
+    - [opensuse/tmbl,  latest,   3004.0,      3]  # opsu-tmbl-3004.0-py3
+    - [amazonlinux  ,    2   ,   3004.0,      3]  # amaz-02.0-3004.0-py3
+    - [oraclelinux  ,    8   ,   3004.0,      3]  # orac-08.0-3004.0-py3
+    - [oraclelinux  ,    7   ,   3004.0,      3]  # orac-07.0-3004.0-py3
+    - [arch-base    ,  latest,   3004.0,      3]  # arch-late-3004.0-py3
+    - [gentoo/stage3,  latest,   3004.0,      3]  # gent-late-3004.0-py3
+    - [gentoo/stage3, systemd,   3004.0,      3]  # gent-sysd-3004.0-py3
+    - [almalinux    ,    8   ,   3004.0,      3]  # alma-08.0-3004.0-py3
+    - [rockylinux   ,    8   ,   3004.0,      3]  # rock-08.0-3004.0-py3
 
     ### `3003.3-py3`
     - [debian       ,   11   ,   3003.3,      3]  # debi-11.0-3003.3-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -68,8 +68,8 @@ ssf_node_anchors:
             #       An alternative method could be to use:
             #       `git describe --abbrev=0 --tags`
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci: use '`'pillars_from_directories'`' & '`'test/salt/pillar/top.sls'`'"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/384'
+            title: "ci(kitchen+ci): update with '`'3004'`' pre-salted images/boxes [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/385'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -1179,6 +1179,9 @@ ssf:
           3:
             <<: *isk_suite_default
             name: 'domains'
+          4:
+            <<: *isk_suite_default
+            name: 'pip'
     libvirt:
       <<: *formula_default
       context:

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -345,8 +345,8 @@ ssf:
     ### `freebsd`
     - [freebsd      ,   13.0 ,   master,      3]  # fbsd-13.0-master-py3
     - [freebsd      ,   12.2 ,   master,      3]  # fbsd-12.2-master-py3
-    - [freebsd      ,   13.0 ,   3003.1,      3]  # fbsd-13.0-3003.1-py3
-    - [freebsd      ,   12.2 ,   3003.1,      3]  # fbsd-12.2-3003.1-py3
+    - [freebsd      ,   13.0 ,   3004.0,      3]  # fbsd-13.0-3004.0-py3
+    - [freebsd      ,   12.2 ,   3004.0,      3]  # fbsd-12.2-3004.0-py3
     ### `openbsd`
     - [openbsd      ,    7.0 ,   3003.3,      3]  # obsd-07.0-3003.3-py3
     - [openbsd      ,    6.9 ,   3002.6,      3]  # obsd-06.9-3002.6-py3
@@ -357,6 +357,8 @@ ssf:
     ### Deprecated, no longer being built but still available in Vagrant Cloud
     ### `freebsd`
     - [freebsd      ,   11.4 ,   master,      3]  # fbsd-11.4-master-py3
+    - [freebsd      ,   13.0 ,   3003.1,      3]  # fbsd-13.0-3003.1-py3
+    - [freebsd      ,   12.2 ,   3003.1,      3]  # fbsd-12.2-3003.1-py3
     - [freebsd      ,   11.4 ,   3003.1,      3]  # fbsd-11.4-3003.1-py3
     - [freebsd      ,   13.0 ,   3002.6,      3]  # fbsd-13.0-3002.6-py3
     - [freebsd      ,   12.2 ,   3002.6,      3]  # fbsd-12.2-3002.6-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -376,6 +376,7 @@ ssf:
     - [debian       ,    9   ,   tiamat,      3]  # debi-09.0-tiamat-py3
     - [ubuntu       ,   20.04,   tiamat,      3]  # ubun-20.0-tiamat-py3
     - [ubuntu       ,   18.04,   tiamat,      3]  # ubun-18.0-tiamat-py3
+    - [centos       , stream8,   tiamat,      3]  # cstr-08.0-tiamat-py3
     - [centos       ,    8   ,   tiamat,      3]  # cent-08.0-tiamat-py3
     - [centos       ,    7   ,   tiamat,      3]  # cent-07.0-tiamat-py3
     # # Not available at the current time
@@ -396,6 +397,7 @@ ssf:
     - [debian       ,    9   ,   master,      3]  # debi-09.0-master-py3
     - [ubuntu       ,   20.04,   master,      3]  # ubun-20.0-master-py3
     - [ubuntu       ,   18.04,   master,      3]  # ubun-18.0-master-py3
+    - [centos       , stream8,   master,      3]  # cstr-08.0-master-py3
     - [centos       ,    8   ,   master,      3]  # cent-08.0-master-py3
     - [centos       ,    7   ,   master,      3]  # cent-07.0-master-py3
     - [fedora       ,   34   ,   master,      3]  # fedo-34.0-master-py3
@@ -418,6 +420,7 @@ ssf:
     - [debian       ,    9   ,   3003.3,      3]  # debi-09.0-3003.3-py3
     - [ubuntu       ,   20.04,   3003.3,      3]  # ubun-20.0-3003.3-py3
     - [ubuntu       ,   18.04,   3003.3,      3]  # ubun-18.0-3003.3-py3
+    - [centos       , stream8,   3003.3,      3]  # cstr-08.0-3003.3-py3
     - [centos       ,    8   ,   3003.3,      3]  # cent-08.0-3003.3-py3
     - [centos       ,    7   ,   3003.3,      3]  # cent-07.0-3003.3-py3
     - [fedora       ,   34   ,   3003.3,      3]  # fedo-34.0-3003.3-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -348,6 +348,7 @@ ssf:
     - [freebsd      ,   13.0 ,   3003.1,      3]  # fbsd-13.0-3003.1-py3
     - [freebsd      ,   12.2 ,   3003.1,      3]  # fbsd-12.2-3003.1-py3
     ### `openbsd`
+    - [openbsd      ,    7.0 ,   3003.3,      3]  # obsd-07.0-3003.3-py3
     - [openbsd      ,    6.9 ,   3002.6,      3]  # obsd-06.9-3002.6-py3
     ### `windows`
     - [windows      ,   10   ,   latest,      3]  # wind-10.0-latest-py3

--- a/ssf/files/default/.gitlab-ci.yml
+++ b/ssf/files/default/.gitlab-ci.yml
@@ -135,7 +135,7 @@ rubocop:
 ###############################################################################
 # Define `test` template
 ###############################################################################
-.test_instance:{{ ' &test_instance' if platforms_matrix_allow_failure else '' }}
+.test_instance: &test_instance
   stage: *stage_test
   image: *image_dindruby
   services: *services_docker_dind
@@ -154,15 +154,12 @@ rubocop:
     # Alternative value to consider: `${CI_JOB_NAME}`
     - '{{ script_kitchen.bin }} {{ script_kitchen.cmd }} "${DOCKER_ENV_CI_JOB_NAME}"'
 
-{%-   if platforms_matrix_allow_failure %}
-
 ###############################################################################
 # Define `test` template (`allow_failure: true`)
 ###############################################################################
 .test_instance_failure_permitted:
   <<: *test_instance
   allow_failure: true
-{%-   endif %}
 
 {%-   if semrel_formula == 'template' %}
 # <REMOVEME

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -4365,6 +4365,8 @@ ssf:
             top_sls:
               - '*':
                   - salt
+              - 'G@saltversioninfo:0:3004 and G@pythonversion:0:3':
+                  - v3004-py3
               - 'G@saltversioninfo:0:3003 and G@pythonversion:0:3':
                   - v3003-py3
               - 'G@saltversioninfo:0:3002 and G@pythonversion:0:3':
@@ -4376,16 +4378,17 @@ ssf:
             import: ['salt_settings', 'formulas_settings']
         platforms_matrix:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
-          - [debian       ,   11   ,   3003.3,      3,         default]
-          - [debian       ,   10   ,   3002.7,      3,         default]
-          - [debian       ,    9   ,   3001.8,      3,         default]
-          - [ubuntu       ,   20.04,   3003.3,      3,         default]
-          - [ubuntu       ,   18.04,   3002.7,      3,         default]
+          - [debian       ,   11   ,   3004.0,      3,         default]
+          - [debian       ,   10   ,   3003.3,      3,         default]
+          - [debian       ,    9   ,   3002.7,      3,         default]
+          - [ubuntu       ,   20.04,   3004.0,      3,         default]
+          - [ubuntu       ,   18.04,   3003.3,      3,         default]
           # # `centos-stream8` only available after `3003.X`
-          - [centos       , stream8,   3003.3,      3,         default]
-          - [centos       ,    8   ,   3003.3,      3,         default]
-          - [centos       ,    7   ,   3002.7,      3,         default]
+          - [centos       , stream8,   3004.0,      3,         default]
+          - [centos       ,    8   ,   3004.0,      3,         default]
+          - [centos       ,    7   ,   3003.3,      3,         default]
           # # `fedora` only installs `3003.X`
+          - [fedora       ,   35   ,   3003.3,      3,         default]
           - [fedora       ,   34   ,   3003.3,      3,         default]
           - [fedora       ,   33   ,   3003.3,      3,         default]
           # # `opensuse/*` only installs `3003.X`
@@ -4393,27 +4396,22 @@ ssf:
           # # InSpec suite when there's a shared `_mapdata` verification file --
           # # using the currently supported version for now (re: Salt repo)
           - [opensuse/leap,   15.3 ,   3003.3,      3,         default]
+          # - [opensuse/leap,   15.2 ,   3003.3,      3,         default]
           - [opensuse/tmbl,  latest,   3003.3,      3,         default]
-          - [amazonlinux  ,    2   ,   3003.3,      3,         default]
-          - [oraclelinux  ,    8   ,   3003.3,      3,         default]
-          - [oraclelinux  ,    7   ,   3002.7,      3,         default]
+          - [amazonlinux  ,    2   ,   3004.0,      3,         default]
+          - [oraclelinux  ,    8   ,   3004.0,      3,         default]
+          - [oraclelinux  ,    7   ,   3003.3,      3,         default]
           # # `arch` only installs `3004.X`
-          # # This doesn't do anything right now until the `3004.0` pre-salted
-          # # images are pushed to the formula
           - [arch-base    ,  latest,   3004.0,      3,         default]
           - [gentoo/stage3,  latest,   3003.3,      3,         default]
           - [gentoo/stage3, systemd,   3003.3,      3,         default]
-          - [almalinux    ,    8   ,   3003.3,      3,         default]
-          # # TODO: When supported in an official release, move this platform
-          # #       to that release (as a minimum, no other Salt versions)
-          - [rockylinux   ,    8   ,   3003.3,      3,         default]
+          - [almalinux    ,    8   ,   3004.0,      3,         default]
+          - [rockylinux   ,    8   ,   3004.0,      3,         default]
           # # FreeBSD and Windows won't always be in sync with the Linux
           # # platforms above
           - [freebsd      ,    0   ,   3003.1,      3,         default]
           - [openbsd      ,    0   ,   3002.6,      3,         default]
           - [windows      ,    0   ,   latest,      3,         default]
-        platforms_matrix_allow_failure:
-          - [debian       ,   11   ,   3003.3,      3,         default]
         testing_freebsd:
           active: true
         testing_openbsd:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2441,12 +2441,9 @@ ssf:
                 Verify that the letsencrypt formula is setup and configured correctly
                 using `git`
             provisioner:
-              pillars:
-                - '*':
-                    - .
               pillars_from_files:
                 - .sls: 'test/salt/pillar/git.sls'
-              state_top:
+              state_top: &state_top_letsencrypt_install_and_config
                 - '*':
                     - ._mapdata
                     - .install
@@ -2484,16 +2481,9 @@ ssf:
                 Verify that the letsencrypt formula is setup and configured correctly
                 on RedHat (and derivatives)
             provisioner:
-              pillars:
-                - '*':
-                    - .
               pillars_from_files:
                 - .sls: 'test/salt/pillar/rpm.sls'
-              state_top:
-                - '*':
-                    - ._mapdata
-                    - .install
-                    - .config
+              state_top: *state_top_letsencrypt_install_and_config
           3:
             includes: *platforms_osfamily_debian
             inspec_yml:
@@ -2509,11 +2499,21 @@ ssf:
                     - ._mapdata
                     - states.install_letsencrypt_test_server
                     - .
+          4:
+            inspec_yml:
+              summary: >-
+                Verify that the letsencrypt formula is setup and configured correctly
+                using `pip`
+            provisioner:
+              pillars_from_files:
+                - .sls: 'test/salt/pillar/pip.sls'
+              state_top: *state_top_letsencrypt_install_and_config
         inspec_suites_matrix:
           - git
           - deb
           - rpm
           - domains
+          - pip
         map_jinja:
           verification:
             import: ['letsencrypt']
@@ -2540,8 +2540,9 @@ ssf:
           # # Should work but failing dependency resolution
           # # - [oraclelinux  ,    0   ,   master,      0,             rpm]
           - [oraclelinux  ,    8   ,   master,      0,             rpm]
-          - [arch-base    ,    0   ,   master,      0,             git]
-          - [gentoo/stage3,    0   ,   master,      0,             git]
+          - [arch-base    ,    0   ,   master,      0,             pip]
+          - [gentoo/stage3,  latest,   master,      0,             git]
+          - [gentoo/stage3, systemd,   master,      0,             pip]
           - [almalinux    ,    0   ,   master,      0,             rpm]
           - [rockylinux   ,    0   ,   master,      0,             rpm]
       semrel_files: *semrel_files_default

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -105,6 +105,7 @@ ssf_node_anchors:
         platforms_os_redhat_locale_specific: &platforms_os_redhat_locale_specific
           # [os           ,  os_ver, salt_ver, py_ver]
           # # - [centos       ,    0   ,      0  ,      0]
+          - [centos       , stream8,      0  ,      0]
           - [centos       ,    8   ,      0  ,      0]
           - [fedora       ,    0   ,      0  ,      0]
           - [amazonlinux  ,    0   ,      0  ,      0]
@@ -1281,6 +1282,7 @@ ssf:
           - [debian       ,    0   ,   master,      0,              '']
           - [ubuntu       ,    0   ,   master,      0,              '']
           # # - [centos       ,    0   ,   master,      0,              '']
+          - [centos       , stream8,   master,      0,              '']
           - [centos       ,    8   ,   master,      0,              '']
           - [centos       ,    7   ,   master,      0,         package]
           - [fedora       ,    0   ,   master,      0,              '']
@@ -1486,6 +1488,7 @@ ssf:
           - [debian       ,   10   ,   master,      0,         default]
           - [debian       ,    9   ,   master,      0,              '']
           - [ubuntu       ,    0   ,   master,      0,              '']
+          - [centos       , stream8,   master,      0,         default]
           - [centos       ,    8   ,   master,      0,         default]
           - [centos       ,    7   ,   master,      0,              '']
           - [fedora       ,    0   ,   master,      0,              '']
@@ -2629,6 +2632,7 @@ ssf:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [debian       ,    0   ,   master,      0,         default]
           - [ubuntu       ,    0   ,   master,      0,         default]
+          - [centos       , stream8,   master,      0,          redhat]
           - [centos       ,    8   ,   master,      0,          redhat]
           # RedHat-7 not working with the `redhat` suite, due to packages
           # - `glibc-langpack-de` not available, `glibc-common` is sufficient
@@ -3473,6 +3477,7 @@ ssf:
           4:
             includes:
               # Some of `*platforms_os_centos` + `oraclelinux-8`
+              - [centos       , stream8,      0  ,      0]
               - [centos       ,    8   ,      0  ,      0]
               - [oraclelinux  ,    8   ,      0  ,      0]
               - [almalinux    ,    0   ,      0  ,      0]
@@ -3580,6 +3585,7 @@ ssf:
           # # - [ubuntu       ,    0   ,   master,      0,          ubuntu]
           - [ubuntu       ,   18.04,   master,      0,          ubuntu]
           # # - [centos       ,    0   ,   master,      0,         redhat8]
+          - [centos       , stream8,   master,      0,         redhat8]
           - [centos       ,    8   ,   master,      0,         redhat8]
           - [centos       ,    7   ,   master,      0,          centos]
           # # - [fedora       ,    0   ,   master,      0,          fedora]
@@ -4375,6 +4381,8 @@ ssf:
           - [debian       ,    9   ,   3001.8,      3,         default]
           - [ubuntu       ,   20.04,   3003.3,      3,         default]
           - [ubuntu       ,   18.04,   3002.7,      3,         default]
+          # # `centos-stream8` only available after `3003.X`
+          - [centos       , stream8,   3003.3,      3,         default]
           - [centos       ,    8   ,   3003.3,      3,         default]
           - [centos       ,    7   ,   3002.7,      3,         default]
           # # `fedora` only installs `3003.X`
@@ -5040,6 +5048,7 @@ ssf:
             includes:
               - [debian       ,   11   ,      0  ,      0]
               - [debian       ,   10   ,      0  ,      0]
+              - [centos       , stream8,      0  ,      0]
               - [centos       ,    8   ,      0  ,      0]
               - [oraclelinux  ,    8   ,      0  ,      0]
               - [almalinux    ,    0   ,      0  ,      0]
@@ -5078,6 +5087,7 @@ ssf:
           - [debian       ,    9   ,   master,      0,    without-ipv6]
           - [ubuntu       ,    0   ,   master,      0,    without-ipv6]
           # # - [centos       ,    0   ,   master,      0,    without-ipv6]
+          - [centos       , stream8,   master,      0,         default]
           - [centos       ,    8   ,   master,      0,         default]
           - [centos       ,    7   ,   master,      0,    without-ipv6]
           - [fedora       ,    0   ,   master,      0,    without-ipv6]
@@ -5223,6 +5233,7 @@ ssf:
           # # - [ubuntu       ,    0   ,   master,      0,         default]
           - [ubuntu       ,   20.04,   master,      0,         default]
           # # - [centos       ,    0   ,   master,      0,         default]
+          - [centos       , stream8,   master,      0,         default]
           - [centos       ,    8   ,   master,      0,         default]
           - [fedora       ,    0   ,   master,      0,         default]
           - [opensuse/leap,    0   ,   master,      0,         default]

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -4411,7 +4411,7 @@ ssf:
           - [rockylinux   ,    8   ,   3004.0,      3,         default]
           # # FreeBSD and Windows won't always be in sync with the Linux
           # # platforms above
-          - [freebsd      ,    0   ,   3003.1,      3,         default]
+          - [freebsd      ,    0   ,   3004.0,      3,         default]
           - [openbsd      ,    7.0 ,   3003.3,      3,         default]
           - [openbsd      ,    6.9 ,   3002.6,      3,         default]
           - [windows      ,    0   ,   latest,      3,         default]

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -3125,6 +3125,7 @@ ssf:
           ignore:
             additional:
               - node/osfamilymap.yaml
+              - test/salt/pillar/repo.sls
       semrel_files: *semrel_files_default
     nsd:
       context:

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -4412,7 +4412,8 @@ ssf:
           # # FreeBSD and Windows won't always be in sync with the Linux
           # # platforms above
           - [freebsd      ,    0   ,   3003.1,      3,         default]
-          - [openbsd      ,    0   ,   3002.6,      3,         default]
+          - [openbsd      ,    7.0 ,   3003.3,      3,         default]
+          - [openbsd      ,    6.9 ,   3002.6,      3,         default]
           - [windows      ,    0   ,   latest,      3,         default]
         testing_freebsd:
           active: true

--- a/ssf/libcimatrix.jinja
+++ b/ssf/libcimatrix.jinja
@@ -185,7 +185,11 @@
 {%-               if use_gitlab_format %}
 {%-                 set list_format = '' %}
 {%-                 set test_template = ": {extends: '.test_instance'}" %}
-{%-                 if [os, os_ver, salt_ver, py_ver, suite_name] in platforms_matrix_allow_failure %}
+{#-                 Was originally only using `platforms_matrix_allow_failure` for this but #}
+{#-                 now using with specific platforms on top until they stabilise #}
+{%-                 if ([os, os_ver, salt_ver, py_ver, suite_name] in platforms_matrix_allow_failure) or
+                       ([os, os_ver] in [['fedora', 35], ['opensuse/tmbl', 'latest'], ['centos', 'stream8']])
+%}
 {%-                   set test_template = ": {extends: '.test_instance_failure_permitted'}" %}
 {%-                 endif %}
 {%-               else %}


### PR DESCRIPTION
feat(saltimages): update with latest changes from `salt-image-builder`

* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/128
* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/129
* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/130

---

Also includes:

* feat(gitlab-ci): allow failure for new/unstable platforms in general
  - Whereas the Debian 11 (and other) instances are being allowed to fail selectively where needed in specific formulas, this is too much to do for the new (CentOS Stream 8) or unstable (Fedora 35 & OpenSUSE Tumbleweed) platforms.  Allow failure for these across all instances until the situation stabilises.
* feat(openbsd): deprecate `6.8` (EOL: 2021-10-14)