### PR TITLE
feat(proxy): replace deprecated Windows `2016` with `2022`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(proxy+windows): fix setting up WinRM"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/392'
+            title: "ci(proxy): replace deprecated Windows '`'2016'`' with '`'2022'`' [skip ci]"
+            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/393'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'
@@ -337,7 +337,10 @@ ssf:
         source: 'salt://ssf/files/default/git/git_30_create_PR.sh'
   proxyplatformswindows:
     ### `windows`
+    - [windows      , 2022   ,   latest,      3]  # wind-2022-latest-py3
     - [windows      , 2019   ,   latest,      3]  # wind-2019-latest-py3
+  proxyplatformswindows_deprecated:
+    ### `windows`
     - [windows      , 2016   ,   latest,      3]  # wind-2016-latest-py3
   vagrantboxes:
     ### `freebsd`

--- a/ssf/files/default/kitchen.windows.yml
+++ b/ssf/files/default/kitchen.windows.yml
@@ -17,7 +17,7 @@ provisioner:
   # yamllint disable rule:line-length
   init_environment: |
     {%- for pkg in testing_windows.winrepo_ng %}
-    C:\salt\salt-call --local state.single file.managed `
+    salt-call --local state.single file.managed `
       C:\Users\kitchen\AppData\Local\Temp\kitchen\srv\salt\win\repo-ng\{{ pkg }}.sls `
       source=https://github.com/saltstack/salt-winrepo-ng/raw/master/{{ pkg }}.sls `
       skip_verify=True makedirs=True

--- a/ssf/files/default/test/integration/share/libraries/system.rb
+++ b/ssf/files/default/test/integration/share/libraries/system.rb
@@ -61,6 +61,8 @@ class SystemResource < Inspec.resource(1)
       # rubocop:enable Style/NumericLiterals,Layout/LineLength
     when 'windows_8.1_pro'
       '8.1'
+    when 'windows_server_2022_datacenter'
+      '2022-server'
     when 'windows_server_2019_datacenter'
       '2019-server'
     when 'windows_server_2016_datacenter'


### PR DESCRIPTION
* https://github.com/actions/virtual-environments/issues/4312

---

Also includes:

* feat(proxy): remove literal `C:\salt\` from `salt-call` command
  - Prepare for `3004`, which no longer uses this non-standard path.