### PR TITLE
feat(vagrant): replace FreeBSD 12.2 with 12.3

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile.lock): update to latest gem versions (2021-W51) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/394'
+            title: "ci(vagrant): replace FreeBSD 12.2 with 12.3 [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/395'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'
@@ -345,9 +345,9 @@ ssf:
   vagrantboxes:
     ### `freebsd`
     - [freebsd      ,   13.0 ,   master,      3]  # fbsd-13.0-master-py3
-    - [freebsd      ,   12.2 ,   master,      3]  # fbsd-12.2-master-py3
+    - [freebsd      ,   12.3 ,   master,      3]  # fbsd-12.3-master-py3
     - [freebsd      ,   13.0 ,   3004.0,      3]  # fbsd-13.0-3004.0-py3
-    - [freebsd      ,   12.2 ,   3004.0,      3]  # fbsd-12.2-3004.0-py3
+    - [freebsd      ,   12.3 ,   3004.0,      3]  # fbsd-12.3-3004.0-py3
     ### `openbsd`
     - [openbsd      ,    7.0 ,   3003.3,      3]  # obsd-07.0-3003.3-py3
     - [openbsd      ,    6.9 ,   3002.6,      3]  # obsd-06.9-3002.6-py3
@@ -357,7 +357,9 @@ ssf:
   vagrantboxes_deprecated:
     ### Deprecated, no longer being built but still available in Vagrant Cloud
     ### `freebsd`
+    - [freebsd      ,   12.2 ,   master,      3]  # fbsd-12.2-master-py3
     - [freebsd      ,   11.4 ,   master,      3]  # fbsd-11.4-master-py3
+    - [freebsd      ,   12.2 ,   3004.0,      3]  # fbsd-12.2-3004.0-py3
     - [freebsd      ,   13.0 ,   3003.1,      3]  # fbsd-13.0-3003.1-py3
     - [freebsd      ,   12.2 ,   3003.1,      3]  # fbsd-12.2-3003.1-py3
     - [freebsd      ,   11.4 ,   3003.1,      3]  # fbsd-11.4-3003.1-py3

--- a/ssf/files/default/kitchen.vagrant.yml
+++ b/ssf/files/default/kitchen.vagrant.yml
@@ -46,8 +46,6 @@ platforms:
       cache_directory: "/omnibus/cache"
       customize: {}
       ssh: {}
-      {%- elif [os, os_ver] == ['freebsd', 13.0] %}
-      synced_folders: []  # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255208
       {%- endif %}
     {%- if os == 'windows' %}
     provisioner:


### PR DESCRIPTION
Includes:

* feat(vagrant): allow `synced_folders` on FreeBSD 13.0 (bug fixed)
  - https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255208