### PR TITLE
feat(logrotate): use `cron-formula` dep instead of single `cron` state

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "feat(osfamilymap): add Gentoo support"
-            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/400'
+            title: "ci(kitchen): use '`'cron-formula'`' dependency instead of '`'cron'`' state"
+            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/401'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -2663,12 +2663,14 @@ ssf:
               summary: >-
                 Verify that the logrotate formula is setup and configured correctly
             provisioner:
-              dependencies: *dependencies_states
+              dependencies:
+                - name: 'cron'
+                  repo: 'git'
+                  source: 'https://github.com/saltstack-formulas/cron-formula.git'
               state_top:
-                - 'G@os_family:Suse or G@os_family:Debian':
-                    - states.cron
                 - '*':
                     - ._mapdata
+                    - cron
                     - .
         map_jinja:
           verification:


### PR DESCRIPTION
Use to fix Arch Linux `cron` installation and testing in the formula:

* https://github.com/saltstack-formulas/logrotate-formula/pull/60#issuecomment-1013031092