### PR TITLE
feat(gemfile.lock): use `bundle update` to get latest gems [2022-W12]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 3dab2e31799c850afcd377e331e150e97cc48e85
+  revision: 8b29ba7ad69faeb103c345c560417c5374db8df3
   branch: ssf
   specs:
-    inspec (5.7.10)
+    inspec (5.8.0)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.7.10)
+      inspec-core (= 5.8.0)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.7.10)
+    inspec-core (5.8.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -145,7 +145,7 @@ GEM
     aws-sdk-ec2 (1.303.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ecr (1.55.0)
+    aws-sdk-ecr (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecrpublic (1.12.0)
@@ -303,9 +303,9 @@ GEM
     bcrypt_pbkdf (1.1.0)
     bson (4.14.1)
     builder (3.2.4)
-    chef-config (17.9.52)
+    chef-config (17.10.0)
       addressable
-      chef-utils (= 17.9.52)
+      chef-utils (= 17.10.0)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -313,10 +313,10 @@ GEM
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (17.9.52)
+    chef-utils (17.10.0)
       concurrent-ruby
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cookstyle (7.32.1)
       rubocop (= 1.25.1)
     declarative (0.0.20)
@@ -328,7 +328,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.3.0)
     erubi (1.10.0)
-    excon (0.92.0)
+    excon (0.92.1)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -431,7 +431,7 @@ GEM
     nori (2.6.0)
     options (2.3.2)
     os (1.1.4)
-    parallel (1.21.0)
+    parallel (1.22.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
     parslet (1.8.2)

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile.lock): update to latest gem versions (2022-W11) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/423'
+            title: "chore(gemfile.lock): update to latest gem versions (2022-W12) [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/424'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/Gemfile.lock
+++ b/ssf/files/default/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 3dab2e31799c850afcd377e331e150e97cc48e85
+  revision: 8b29ba7ad69faeb103c345c560417c5374db8df3
   branch: ssf
   specs:
-    inspec (5.7.10)
+    inspec (5.8.0)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.7.10)
+      inspec-core (= 5.8.0)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.7.10)
+    inspec-core (5.8.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -145,7 +145,7 @@ GEM
     aws-sdk-ec2 (1.303.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ecr (1.55.0)
+    aws-sdk-ecr (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecrpublic (1.12.0)
@@ -303,9 +303,9 @@ GEM
     bcrypt_pbkdf (1.1.0)
     bson (4.14.1)
     builder (3.2.4)
-    chef-config (17.9.52)
+    chef-config (17.10.0)
       addressable
-      chef-utils (= 17.9.52)
+      chef-utils (= 17.10.0)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -313,10 +313,10 @@ GEM
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (17.9.52)
+    chef-utils (17.10.0)
       concurrent-ruby
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cookstyle (7.32.1)
       rubocop (= 1.25.1)
     declarative (0.0.20)
@@ -328,7 +328,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.3.0)
     erubi (1.10.0)
-    excon (0.92.0)
+    excon (0.92.1)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -431,7 +431,7 @@ GEM
     nori (2.6.0)
     options (2.3.2)
     os (1.1.4)
-    parallel (1.21.0)
+    parallel (1.22.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
     parslet (1.8.2)

--- a/ssf/files/tofs_openssh-formula/Gemfile.lock
+++ b/ssf/files/tofs_openssh-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 3dab2e31799c850afcd377e331e150e97cc48e85
+  revision: 8b29ba7ad69faeb103c345c560417c5374db8df3
   branch: ssf
   specs:
-    inspec (5.7.10)
+    inspec (5.8.0)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.7.10)
+      inspec-core (= 5.8.0)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.7.10)
+    inspec-core (5.8.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -145,7 +145,7 @@ GEM
     aws-sdk-ec2 (1.303.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ecr (1.55.0)
+    aws-sdk-ecr (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecrpublic (1.12.0)
@@ -303,9 +303,9 @@ GEM
     bcrypt_pbkdf (1.1.0)
     bson (4.14.1)
     builder (3.2.4)
-    chef-config (17.9.52)
+    chef-config (17.10.0)
       addressable
-      chef-utils (= 17.9.52)
+      chef-utils (= 17.10.0)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -313,10 +313,10 @@ GEM
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (17.9.52)
+    chef-utils (17.10.0)
       concurrent-ruby
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cookstyle (7.32.1)
       rubocop (= 1.25.1)
     declarative (0.0.20)
@@ -328,7 +328,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.3.0)
     erubi (1.10.0)
-    excon (0.92.0)
+    excon (0.92.1)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -433,7 +433,7 @@ GEM
     nori (2.6.0)
     options (2.3.2)
     os (1.1.4)
-    parallel (1.21.0)
+    parallel (1.22.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
     parslet (1.8.2)

--- a/ssf/files/tofs_openvpn-formula/Gemfile.lock
+++ b/ssf/files/tofs_openvpn-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 3dab2e31799c850afcd377e331e150e97cc48e85
+  revision: 8b29ba7ad69faeb103c345c560417c5374db8df3
   branch: ssf
   specs:
-    inspec (5.7.10)
+    inspec (5.8.0)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.7.10)
+      inspec-core (= 5.8.0)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.7.10)
+    inspec-core (5.8.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -145,7 +145,7 @@ GEM
     aws-sdk-ec2 (1.303.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ecr (1.55.0)
+    aws-sdk-ecr (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecrpublic (1.12.0)
@@ -303,9 +303,9 @@ GEM
     bcrypt_pbkdf (1.1.0)
     bson (4.14.1)
     builder (3.2.4)
-    chef-config (17.9.52)
+    chef-config (17.10.0)
       addressable
-      chef-utils (= 17.9.52)
+      chef-utils (= 17.10.0)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -313,10 +313,10 @@ GEM
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (17.9.52)
+    chef-utils (17.10.0)
       concurrent-ruby
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cookstyle (7.32.1)
       rubocop (= 1.25.1)
     declarative (0.0.20)
@@ -328,7 +328,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.3.0)
     erubi (1.10.0)
-    excon (0.92.0)
+    excon (0.92.1)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -433,7 +433,7 @@ GEM
     nori (2.6.0)
     options (2.3.2)
     os (1.1.4)
-    parallel (1.21.0)
+    parallel (1.22.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
     parslet (1.8.2)


### PR DESCRIPTION
Test using latest `master` branch images:

* https://github.com/myii/salt/commit/8bef3a81ec695e76ac8c5048074ec933ec2e83ca
  - Includes one extra commit to avoid images being built as `3005`.
  - Includes another extra commit to avoid recent `include` regression in `master` branch.

Test results:

* https://saltstack-formulas.zulipchat.com/#narrow/stream/239693-CI/topic/myii-ci.2F2022-W12a