### PR TITLE
feat(gemfile.lock): use `bundle update` to get latest gems [2022-W14]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 36118e817641fbc1d4bd9753a77c383e7b20caff
+  revision: 31b5b09a827ed9fcbc0b2d550ae4056013dcc92e
   branch: ssf
   specs:
-    inspec (5.10.7)
+    inspec (5.10.11)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.10.7)
+      inspec-core (= 5.10.11)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.10.7)
+    inspec-core (5.10.11)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.571.0)
+    aws-partitions (1.573.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -142,7 +142,7 @@ GEM
     aws-sdk-dynamodb (1.74.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.304.0)
+    aws-sdk-ec2 (1.305.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.56.0)
@@ -328,7 +328,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.3.0)
     erubi (1.10.0)
-    excon (0.92.1)
+    excon (0.92.2)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -367,8 +367,9 @@ GEM
       signet (~> 0.14)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    gyoku (1.3.1)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
+      rexml (~> 3.0)
     hashie (4.1.0)
     highline (2.0.3)
     http-cookie (1.0.4)
@@ -407,7 +408,7 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.5)
+    mixlib-shellout (3.2.6)
       chef-utils
     mixlib-versioning (1.2.12)
     mongo (2.13.2)
@@ -465,7 +466,7 @@ GEM
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(kitchen+gitlab): update for new pre-salted images [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/426'
+            title: "chore(gemfile.lock): update to latest gem versions (2022-W14) [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/427'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/Gemfile.lock
+++ b/ssf/files/default/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 36118e817641fbc1d4bd9753a77c383e7b20caff
+  revision: 31b5b09a827ed9fcbc0b2d550ae4056013dcc92e
   branch: ssf
   specs:
-    inspec (5.10.7)
+    inspec (5.10.11)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.10.7)
+      inspec-core (= 5.10.11)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.10.7)
+    inspec-core (5.10.11)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.571.0)
+    aws-partitions (1.573.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -142,7 +142,7 @@ GEM
     aws-sdk-dynamodb (1.74.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.304.0)
+    aws-sdk-ec2 (1.305.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.56.0)
@@ -328,7 +328,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.3.0)
     erubi (1.10.0)
-    excon (0.92.1)
+    excon (0.92.2)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -367,8 +367,9 @@ GEM
       signet (~> 0.14)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    gyoku (1.3.1)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
+      rexml (~> 3.0)
     hashie (4.1.0)
     highline (2.0.3)
     http-cookie (1.0.4)
@@ -407,7 +408,7 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.5)
+    mixlib-shellout (3.2.6)
       chef-utils
     mixlib-versioning (1.2.12)
     mongo (2.13.2)
@@ -465,7 +466,7 @@ GEM
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)

--- a/ssf/files/tofs_openssh-formula/Gemfile.lock
+++ b/ssf/files/tofs_openssh-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 36118e817641fbc1d4bd9753a77c383e7b20caff
+  revision: 31b5b09a827ed9fcbc0b2d550ae4056013dcc92e
   branch: ssf
   specs:
-    inspec (5.10.7)
+    inspec (5.10.11)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.10.7)
+      inspec-core (= 5.10.11)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.10.7)
+    inspec-core (5.10.11)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.571.0)
+    aws-partitions (1.573.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -142,7 +142,7 @@ GEM
     aws-sdk-dynamodb (1.74.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.304.0)
+    aws-sdk-ec2 (1.305.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.56.0)
@@ -328,7 +328,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.3.0)
     erubi (1.10.0)
-    excon (0.92.1)
+    excon (0.92.2)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -367,8 +367,9 @@ GEM
       signet (~> 0.14)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    gyoku (1.3.1)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
+      rexml (~> 3.0)
     hashie (4.1.0)
     highline (2.0.3)
     http-cookie (1.0.4)
@@ -409,7 +410,7 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.5)
+    mixlib-shellout (3.2.6)
       chef-utils
     mixlib-versioning (1.2.12)
     mongo (2.13.2)
@@ -467,7 +468,7 @@ GEM
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)

--- a/ssf/files/tofs_openvpn-formula/Gemfile.lock
+++ b/ssf/files/tofs_openvpn-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 36118e817641fbc1d4bd9753a77c383e7b20caff
+  revision: 31b5b09a827ed9fcbc0b2d550ae4056013dcc92e
   branch: ssf
   specs:
-    inspec (5.10.7)
+    inspec (5.10.11)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.10.7)
+      inspec-core (= 5.10.11)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.10.7)
+    inspec-core (5.10.11)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.571.0)
+    aws-partitions (1.573.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -142,7 +142,7 @@ GEM
     aws-sdk-dynamodb (1.74.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.304.0)
+    aws-sdk-ec2 (1.305.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.56.0)
@@ -328,7 +328,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.3.0)
     erubi (1.10.0)
-    excon (0.92.1)
+    excon (0.92.2)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -367,8 +367,9 @@ GEM
       signet (~> 0.14)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    gyoku (1.3.1)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
+      rexml (~> 3.0)
     hashie (4.1.0)
     highline (2.0.3)
     http-cookie (1.0.4)
@@ -409,7 +410,7 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.5)
+    mixlib-shellout (3.2.6)
       chef-utils
     mixlib-versioning (1.2.12)
     mongo (2.13.2)
@@ -467,7 +468,7 @@ GEM
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-retry (0.6.2)


### PR DESCRIPTION
Test using latest `master` branch images:

* https://github.com/myii/salt/commit/613f4f5767465fbb0818f6d1e18e68e64463713c
  - Includes one extra commit to avoid images being built as `3005`.

Test results:

* https://saltstack-formulas.zulipchat.com/#narrow/stream/239693-CI/topic/myii-ci.2F2022-W14a