### PR TITLE
feat(gemfile.lock): use `bundle update` to get latest gems [2022-W15]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 31b5b09a827ed9fcbc0b2d550ae4056013dcc92e
+  revision: 1821d2dfd3365e8f05b8439845c58fa4d069806b
   branch: ssf
   specs:
-    inspec (5.10.11)
+    inspec (5.12.2)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.10.11)
+      inspec-core (= 5.12.2)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.10.11)
+    inspec-core (5.12.2)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -40,7 +40,7 @@ GIT
 
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker
-  revision: 4e03ca42d98624323c1c2d91ceb39c09a29bbfc8
+  revision: 9a09bc1e571e25f3ccabf4725ca2048d970fff82
   branch: ssf
   specs:
     kitchen-docker (2.12.0)
@@ -58,14 +58,14 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.573.0)
+    aws-partitions (1.574.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-amplify (1.32.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-apigateway (1.75.0)
+    aws-sdk-apigateway (1.76.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-apigatewayv2 (1.42.0)
@@ -125,7 +125,7 @@ GEM
     aws-sdk-cognitoidentityprovider (1.53.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-configservice (1.76.0)
+    aws-sdk-configservice (1.77.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-core (3.130.0)
@@ -202,7 +202,7 @@ GEM
     aws-sdk-kms (1.55.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-lambda (1.82.0)
+    aws-sdk-lambda (1.83.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-mq (1.40.0)
@@ -245,7 +245,7 @@ GEM
     aws-sdk-secretsmanager (1.46.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-securityhub (1.62.0)
+    aws-sdk-securityhub (1.63.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-servicecatalog (1.60.0)
@@ -263,7 +263,7 @@ GEM
     aws-sdk-simpledb (1.29.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv2 (~> 1.0)
-    aws-sdk-sms (1.39.0)
+    aws-sdk-sms (1.40.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-sns (1.53.0)
@@ -408,7 +408,7 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.6)
+    mixlib-shellout (3.2.7)
       chef-utils
     mixlib-versioning (1.2.12)
     mongo (2.13.2)
@@ -447,7 +447,7 @@ GEM
     public_suffix (4.0.6)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.1)
+    regexp_parser (2.3.0)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -479,7 +479,7 @@ GEM
       rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
+    rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -515,7 +515,7 @@ GEM
     timeliness (0.3.10)
     tomlrb (1.3.0)
     trailblazer-option (0.1.2)
-    train (3.8.9)
+    train (3.9.2)
       activesupport (>= 6.0.3.1)
       azure_graph_rbac (~> 0.16)
       azure_mgmt_key_vault (~> 0.17)
@@ -526,7 +526,7 @@ GEM
       google-api-client (>= 0.23.9, <= 0.52.0)
       googleauth (>= 0.6.6, <= 0.14.0)
       inifile (~> 3.0)
-      train-core (= 3.8.9)
+      train-core (= 3.9.2)
       train-winrm (~> 0.2)
     train-aws (0.2.24)
       aws-sdk-alexaforbusiness (~> 1.0)
@@ -604,7 +604,7 @@ GEM
       aws-sdk-synthetics (~> 1.19.0)
       aws-sdk-transfer (>= 1.26, < 1.35)
       aws-sdk-waf (~> 1.43.0)
-    train-core (3.8.9)
+    train-core (3.9.2)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci(kitchen+gitlab): update for new pre-salted images [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/429'
+            title: "chore(gemfile.lock): update to latest gem versions (2022-W15) [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/428'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/Gemfile.lock
+++ b/ssf/files/default/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 31b5b09a827ed9fcbc0b2d550ae4056013dcc92e
+  revision: 1821d2dfd3365e8f05b8439845c58fa4d069806b
   branch: ssf
   specs:
-    inspec (5.10.11)
+    inspec (5.12.2)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.10.11)
+      inspec-core (= 5.12.2)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.10.11)
+    inspec-core (5.12.2)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -40,7 +40,7 @@ GIT
 
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker
-  revision: 4e03ca42d98624323c1c2d91ceb39c09a29bbfc8
+  revision: 9a09bc1e571e25f3ccabf4725ca2048d970fff82
   branch: ssf
   specs:
     kitchen-docker (2.12.0)
@@ -58,14 +58,14 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.573.0)
+    aws-partitions (1.574.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-amplify (1.32.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-apigateway (1.75.0)
+    aws-sdk-apigateway (1.76.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-apigatewayv2 (1.42.0)
@@ -125,7 +125,7 @@ GEM
     aws-sdk-cognitoidentityprovider (1.53.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-configservice (1.76.0)
+    aws-sdk-configservice (1.77.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-core (3.130.0)
@@ -202,7 +202,7 @@ GEM
     aws-sdk-kms (1.55.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-lambda (1.82.0)
+    aws-sdk-lambda (1.83.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-mq (1.40.0)
@@ -245,7 +245,7 @@ GEM
     aws-sdk-secretsmanager (1.46.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-securityhub (1.62.0)
+    aws-sdk-securityhub (1.63.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-servicecatalog (1.60.0)
@@ -263,7 +263,7 @@ GEM
     aws-sdk-simpledb (1.29.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv2 (~> 1.0)
-    aws-sdk-sms (1.39.0)
+    aws-sdk-sms (1.40.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-sns (1.53.0)
@@ -408,7 +408,7 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.6)
+    mixlib-shellout (3.2.7)
       chef-utils
     mixlib-versioning (1.2.12)
     mongo (2.13.2)
@@ -447,7 +447,7 @@ GEM
     public_suffix (4.0.6)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.1)
+    regexp_parser (2.3.0)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -479,7 +479,7 @@ GEM
       rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
+    rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -515,7 +515,7 @@ GEM
     timeliness (0.3.10)
     tomlrb (1.3.0)
     trailblazer-option (0.1.2)
-    train (3.8.9)
+    train (3.9.2)
       activesupport (>= 6.0.3.1)
       azure_graph_rbac (~> 0.16)
       azure_mgmt_key_vault (~> 0.17)
@@ -526,7 +526,7 @@ GEM
       google-api-client (>= 0.23.9, <= 0.52.0)
       googleauth (>= 0.6.6, <= 0.14.0)
       inifile (~> 3.0)
-      train-core (= 3.8.9)
+      train-core (= 3.9.2)
       train-winrm (~> 0.2)
     train-aws (0.2.24)
       aws-sdk-alexaforbusiness (~> 1.0)
@@ -604,7 +604,7 @@ GEM
       aws-sdk-synthetics (~> 1.19.0)
       aws-sdk-transfer (>= 1.26, < 1.35)
       aws-sdk-waf (~> 1.43.0)
-    train-core (3.8.9)
+    train-core (3.9.2)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)

--- a/ssf/files/tofs_openssh-formula/Gemfile.lock
+++ b/ssf/files/tofs_openssh-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 31b5b09a827ed9fcbc0b2d550ae4056013dcc92e
+  revision: 1821d2dfd3365e8f05b8439845c58fa4d069806b
   branch: ssf
   specs:
-    inspec (5.10.11)
+    inspec (5.12.2)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.10.11)
+      inspec-core (= 5.12.2)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.10.11)
+    inspec-core (5.12.2)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -40,7 +40,7 @@ GIT
 
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker
-  revision: 4e03ca42d98624323c1c2d91ceb39c09a29bbfc8
+  revision: 9a09bc1e571e25f3ccabf4725ca2048d970fff82
   branch: ssf
   specs:
     kitchen-docker (2.12.0)
@@ -58,14 +58,14 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.573.0)
+    aws-partitions (1.574.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-amplify (1.32.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-apigateway (1.75.0)
+    aws-sdk-apigateway (1.76.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-apigatewayv2 (1.42.0)
@@ -125,7 +125,7 @@ GEM
     aws-sdk-cognitoidentityprovider (1.53.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-configservice (1.76.0)
+    aws-sdk-configservice (1.77.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-core (3.130.0)
@@ -202,7 +202,7 @@ GEM
     aws-sdk-kms (1.55.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-lambda (1.82.0)
+    aws-sdk-lambda (1.83.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-mq (1.40.0)
@@ -245,7 +245,7 @@ GEM
     aws-sdk-secretsmanager (1.46.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-securityhub (1.62.0)
+    aws-sdk-securityhub (1.63.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-servicecatalog (1.60.0)
@@ -263,7 +263,7 @@ GEM
     aws-sdk-simpledb (1.29.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv2 (~> 1.0)
-    aws-sdk-sms (1.39.0)
+    aws-sdk-sms (1.40.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-sns (1.53.0)
@@ -410,7 +410,7 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.6)
+    mixlib-shellout (3.2.7)
       chef-utils
     mixlib-versioning (1.2.12)
     mongo (2.13.2)
@@ -449,7 +449,7 @@ GEM
     public_suffix (4.0.6)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.1)
+    regexp_parser (2.3.0)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -481,7 +481,7 @@ GEM
       rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
+    rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -517,7 +517,7 @@ GEM
     timeliness (0.3.10)
     tomlrb (1.3.0)
     trailblazer-option (0.1.2)
-    train (3.8.9)
+    train (3.9.2)
       activesupport (>= 6.0.3.1)
       azure_graph_rbac (~> 0.16)
       azure_mgmt_key_vault (~> 0.17)
@@ -528,7 +528,7 @@ GEM
       google-api-client (>= 0.23.9, <= 0.52.0)
       googleauth (>= 0.6.6, <= 0.14.0)
       inifile (~> 3.0)
-      train-core (= 3.8.9)
+      train-core (= 3.9.2)
       train-winrm (~> 0.2)
     train-aws (0.2.24)
       aws-sdk-alexaforbusiness (~> 1.0)
@@ -606,7 +606,7 @@ GEM
       aws-sdk-synthetics (~> 1.19.0)
       aws-sdk-transfer (>= 1.26, < 1.35)
       aws-sdk-waf (~> 1.43.0)
-    train-core (3.8.9)
+    train-core (3.9.2)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)

--- a/ssf/files/tofs_openvpn-formula/Gemfile.lock
+++ b/ssf/files/tofs_openvpn-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 31b5b09a827ed9fcbc0b2d550ae4056013dcc92e
+  revision: 1821d2dfd3365e8f05b8439845c58fa4d069806b
   branch: ssf
   specs:
-    inspec (5.10.11)
+    inspec (5.12.2)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.10.11)
+      inspec-core (= 5.12.2)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.10.11)
+    inspec-core (5.12.2)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -40,7 +40,7 @@ GIT
 
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/kitchen-docker
-  revision: 4e03ca42d98624323c1c2d91ceb39c09a29bbfc8
+  revision: 9a09bc1e571e25f3ccabf4725ca2048d970fff82
   branch: ssf
   specs:
     kitchen-docker (2.12.0)
@@ -58,14 +58,14 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.573.0)
+    aws-partitions (1.574.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-amplify (1.32.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-apigateway (1.75.0)
+    aws-sdk-apigateway (1.76.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-apigatewayv2 (1.42.0)
@@ -125,7 +125,7 @@ GEM
     aws-sdk-cognitoidentityprovider (1.53.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-configservice (1.76.0)
+    aws-sdk-configservice (1.77.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-core (3.130.0)
@@ -202,7 +202,7 @@ GEM
     aws-sdk-kms (1.55.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-lambda (1.82.0)
+    aws-sdk-lambda (1.83.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-mq (1.40.0)
@@ -245,7 +245,7 @@ GEM
     aws-sdk-secretsmanager (1.46.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-securityhub (1.62.0)
+    aws-sdk-securityhub (1.63.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-servicecatalog (1.60.0)
@@ -263,7 +263,7 @@ GEM
     aws-sdk-simpledb (1.29.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv2 (~> 1.0)
-    aws-sdk-sms (1.39.0)
+    aws-sdk-sms (1.40.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-sns (1.53.0)
@@ -410,7 +410,7 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.6)
+    mixlib-shellout (3.2.7)
       chef-utils
     mixlib-versioning (1.2.12)
     mongo (2.13.2)
@@ -449,7 +449,7 @@ GEM
     public_suffix (4.0.6)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.1)
+    regexp_parser (2.3.0)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -483,7 +483,7 @@ GEM
       rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
+    rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -519,7 +519,7 @@ GEM
     timeliness (0.3.10)
     tomlrb (1.3.0)
     trailblazer-option (0.1.2)
-    train (3.8.9)
+    train (3.9.2)
       activesupport (>= 6.0.3.1)
       azure_graph_rbac (~> 0.16)
       azure_mgmt_key_vault (~> 0.17)
@@ -530,7 +530,7 @@ GEM
       google-api-client (>= 0.23.9, <= 0.52.0)
       googleauth (>= 0.6.6, <= 0.14.0)
       inifile (~> 3.0)
-      train-core (= 3.8.9)
+      train-core (= 3.9.2)
       train-winrm (~> 0.2)
     train-aws (0.2.24)
       aws-sdk-alexaforbusiness (~> 1.0)
@@ -608,7 +608,7 @@ GEM
       aws-sdk-synthetics (~> 1.19.0)
       aws-sdk-transfer (>= 1.26, < 1.35)
       aws-sdk-waf (~> 1.43.0)
-    train-core (3.8.9)
+    train-core (3.9.2)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)


### PR DESCRIPTION
Test using latest `master` branch images:

* https://github.com/myii/salt/commit/18c9b7e3e5f442df64eed83dcc69bad6dc602bf1
  - Includes one extra commit to avoid images being built as `3005`.

Test results:

* https://saltstack-formulas.zulipchat.com/#narrow/stream/239693-CI/topic/myii-ci.2F2022-W15a