### PR TITLE
feat(tomcat): use `pillars_from_directories` & test `pillar/top.sls`

### DIFF
--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile.lock): update to latest gem versions (2022-W15) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/428'
+            title: "ci: use '`'pillars_from_directories'`' & '`'test/salt/pillar/top.sls'`'"
+            body: '* Semi-automated using https://github.com/myii/ssf-formula/pull/430'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -5045,8 +5045,6 @@ ssf:
               summary: >-
                 Verify that the tomcat formula is setup and configured correctly
             provisioner:
-              # pillars_from_files:
-              #   - .sls: 'test/salt/pillar/default.sls'
               state_top:
                 - '*':
                     - ._mapdata
@@ -5058,6 +5056,15 @@ ssf:
                     - .expires
                     - .context
                     - .cluster
+        kitchen:
+          provisioner:
+            pillars_from_directories:
+              - test/salt/pillar
+            top_sls:
+              - '*':
+                  - default
+              - 'G@osfinger:Amazon*Linux-2 or G@osfinger:Fedora*Linux-36':
+                  - no_MaxPermSize
         map_jinja:
           verification:
             import: ['tomcat']


### PR DESCRIPTION
Use this to fix the formula for Amazon Linux 2 & Fedora 36.