### PR TITLE
feat(gemfile.lock): use `bundle update` to get latest gems [2022-W19]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: bb1df209366a8054faff1d85bd2566b5f97b339e
+  revision: ece601f5dd4bacf5d0dca49cd5c13896a7120255
   branch: ssf
   specs:
-    inspec (5.14.5)
+    inspec (5.15.0)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.14.5)
+      inspec-core (= 5.15.0)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.14.5)
+    inspec-core (5.15.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -49,7 +49,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.4)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.584.0)
+    aws-partitions (1.587.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -142,7 +142,7 @@ GEM
     aws-sdk-dynamodb (1.74.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.310.0)
+    aws-sdk-ec2 (1.312.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.56.0)
@@ -220,10 +220,10 @@ GEM
     aws-sdk-ram (1.26.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-rds (1.145.0)
+    aws-sdk-rds (1.146.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-redshift (1.81.0)
+    aws-sdk-redshift (1.82.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53 (1.62.0)
@@ -245,7 +245,7 @@ GEM
     aws-sdk-secretsmanager (1.46.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-securityhub (1.64.0)
+    aws-sdk-securityhub (1.65.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-servicecatalog (1.60.0)
@@ -447,7 +447,7 @@ GEM
     public_suffix (4.0.7)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.3.1)
+    regexp_parser (2.4.0)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile.lock): update to latest gem versions (2022-W18) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/437'
+            title: "chore(gemfile.lock): update to latest gem versions (2022-W19) [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/439'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/Gemfile.lock
+++ b/ssf/files/default/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: bb1df209366a8054faff1d85bd2566b5f97b339e
+  revision: ece601f5dd4bacf5d0dca49cd5c13896a7120255
   branch: ssf
   specs:
-    inspec (5.14.5)
+    inspec (5.15.0)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.14.5)
+      inspec-core (= 5.15.0)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.14.5)
+    inspec-core (5.15.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -49,7 +49,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.4)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.584.0)
+    aws-partitions (1.587.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -142,7 +142,7 @@ GEM
     aws-sdk-dynamodb (1.74.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.310.0)
+    aws-sdk-ec2 (1.312.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.56.0)
@@ -220,10 +220,10 @@ GEM
     aws-sdk-ram (1.26.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-rds (1.145.0)
+    aws-sdk-rds (1.146.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-redshift (1.81.0)
+    aws-sdk-redshift (1.82.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53 (1.62.0)
@@ -245,7 +245,7 @@ GEM
     aws-sdk-secretsmanager (1.46.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-securityhub (1.64.0)
+    aws-sdk-securityhub (1.65.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-servicecatalog (1.60.0)
@@ -447,7 +447,7 @@ GEM
     public_suffix (4.0.7)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.3.1)
+    regexp_parser (2.4.0)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)

--- a/ssf/files/tofs_openssh-formula/Gemfile.lock
+++ b/ssf/files/tofs_openssh-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: bb1df209366a8054faff1d85bd2566b5f97b339e
+  revision: ece601f5dd4bacf5d0dca49cd5c13896a7120255
   branch: ssf
   specs:
-    inspec (5.14.5)
+    inspec (5.15.0)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.14.5)
+      inspec-core (= 5.15.0)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.14.5)
+    inspec-core (5.15.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -49,7 +49,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.4)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.584.0)
+    aws-partitions (1.587.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -142,7 +142,7 @@ GEM
     aws-sdk-dynamodb (1.74.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.310.0)
+    aws-sdk-ec2 (1.312.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.56.0)
@@ -220,10 +220,10 @@ GEM
     aws-sdk-ram (1.26.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-rds (1.145.0)
+    aws-sdk-rds (1.146.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-redshift (1.81.0)
+    aws-sdk-redshift (1.82.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53 (1.62.0)
@@ -245,7 +245,7 @@ GEM
     aws-sdk-secretsmanager (1.46.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-securityhub (1.64.0)
+    aws-sdk-securityhub (1.65.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-servicecatalog (1.60.0)
@@ -449,7 +449,7 @@ GEM
     public_suffix (4.0.7)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.3.1)
+    regexp_parser (2.4.0)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)

--- a/ssf/files/tofs_openvpn-formula/Gemfile.lock
+++ b/ssf/files/tofs_openvpn-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: bb1df209366a8054faff1d85bd2566b5f97b339e
+  revision: ece601f5dd4bacf5d0dca49cd5c13896a7120255
   branch: ssf
   specs:
-    inspec (5.14.5)
+    inspec (5.15.0)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.14.5)
+      inspec-core (= 5.15.0)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.14.5)
+    inspec-core (5.15.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -49,7 +49,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.4)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.584.0)
+    aws-partitions (1.587.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -142,7 +142,7 @@ GEM
     aws-sdk-dynamodb (1.74.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.310.0)
+    aws-sdk-ec2 (1.312.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.56.0)
@@ -220,10 +220,10 @@ GEM
     aws-sdk-ram (1.26.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-rds (1.145.0)
+    aws-sdk-rds (1.146.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-redshift (1.81.0)
+    aws-sdk-redshift (1.82.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53 (1.62.0)
@@ -245,7 +245,7 @@ GEM
     aws-sdk-secretsmanager (1.46.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-securityhub (1.64.0)
+    aws-sdk-securityhub (1.65.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-servicecatalog (1.60.0)
@@ -449,7 +449,7 @@ GEM
     public_suffix (4.0.7)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.3.1)
+    regexp_parser (2.4.0)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)


### PR DESCRIPTION
Test using latest `master` branch images:

* https://github.com/myii/salt/commit/a16af0644a2ca4181ba4ec42c9b679bf901a145f
  - Includes one extra commit to avoid images being built as `3005`.

Test results:

* https://saltstack-formulas.zulipchat.com/#narrow/stream/239693-CI/topic/myii-ci.2F2022-W19a