### PR TITLE
feat(gemfile.lock): use `bundle update` to get latest gems [2022-W23]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 2b56b68db2a758041b9df5b2e4bdc3c6700558ea
+  revision: 6bedc829b7fcec035311d8c6086db5d59414428c
   branch: ssf
   specs:
-    inspec (5.17.4)
+    inspec (5.17.9)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.17.4)
+      inspec-core (= 5.17.9)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.17.4)
+    inspec-core (5.17.9)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.594.0)
+    aws-partitions (1.596.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -226,7 +226,7 @@ GEM
     aws-sdk-redshift (1.82.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-route53 (1.62.0)
+    aws-sdk-route53 (1.63.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53domains (1.40.0)
@@ -380,8 +380,8 @@ GEM
     inifile (3.0.0)
     jmespath (1.6.1)
     json (2.6.2)
-    jwt (2.3.0)
-    kitchen-inspec (2.5.2)
+    jwt (2.4.0)
+    kitchen-inspec (2.6.0)
       hashie (>= 3.4, <= 5.0)
       inspec (>= 2.2.64, < 6.0)
       test-kitchen (>= 2.7, < 4)
@@ -403,7 +403,7 @@ GEM
     minitest (5.15.0)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-install (3.12.16)
+    mixlib-install (3.12.19)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -423,7 +423,7 @@ GEM
       faraday-cookie_jar (~> 0.0.6)
       ms_rest (~> 0.7.6)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile.lock): update to latest gem versions (2022-W22) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/447'
+            title: "chore(gemfile.lock): update to latest gem versions (2022-W23) [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/449'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/files/default/Gemfile.lock
+++ b/ssf/files/default/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 2b56b68db2a758041b9df5b2e4bdc3c6700558ea
+  revision: 6bedc829b7fcec035311d8c6086db5d59414428c
   branch: ssf
   specs:
-    inspec (5.17.4)
+    inspec (5.17.9)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.17.4)
+      inspec-core (= 5.17.9)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.17.4)
+    inspec-core (5.17.9)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.594.0)
+    aws-partitions (1.596.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -226,7 +226,7 @@ GEM
     aws-sdk-redshift (1.82.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-route53 (1.62.0)
+    aws-sdk-route53 (1.63.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53domains (1.40.0)
@@ -380,8 +380,8 @@ GEM
     inifile (3.0.0)
     jmespath (1.6.1)
     json (2.6.2)
-    jwt (2.3.0)
-    kitchen-inspec (2.5.2)
+    jwt (2.4.0)
+    kitchen-inspec (2.6.0)
       hashie (>= 3.4, <= 5.0)
       inspec (>= 2.2.64, < 6.0)
       test-kitchen (>= 2.7, < 4)
@@ -403,7 +403,7 @@ GEM
     minitest (5.15.0)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-install (3.12.16)
+    mixlib-install (3.12.19)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -423,7 +423,7 @@ GEM
       faraday-cookie_jar (~> 0.0.6)
       ms_rest (~> 0.7.6)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)

--- a/ssf/files/tofs_openssh-formula/Gemfile.lock
+++ b/ssf/files/tofs_openssh-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 2b56b68db2a758041b9df5b2e4bdc3c6700558ea
+  revision: 6bedc829b7fcec035311d8c6086db5d59414428c
   branch: ssf
   specs:
-    inspec (5.17.4)
+    inspec (5.17.9)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.17.4)
+      inspec-core (= 5.17.9)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.17.4)
+    inspec-core (5.17.9)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.594.0)
+    aws-partitions (1.596.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -226,7 +226,7 @@ GEM
     aws-sdk-redshift (1.82.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-route53 (1.62.0)
+    aws-sdk-route53 (1.63.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53domains (1.40.0)
@@ -380,8 +380,8 @@ GEM
     inifile (3.0.0)
     jmespath (1.6.1)
     json (2.6.2)
-    jwt (2.3.0)
-    kitchen-inspec (2.5.2)
+    jwt (2.4.0)
+    kitchen-inspec (2.6.0)
       hashie (>= 3.4, <= 5.0)
       inspec (>= 2.2.64, < 6.0)
       test-kitchen (>= 2.7, < 4)
@@ -405,7 +405,7 @@ GEM
     minitest (5.15.0)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-install (3.12.16)
+    mixlib-install (3.12.19)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -425,7 +425,7 @@ GEM
       faraday-cookie_jar (~> 0.0.6)
       ms_rest (~> 0.7.6)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)

--- a/ssf/files/tofs_openvpn-formula/Gemfile.lock
+++ b/ssf/files/tofs_openvpn-formula/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://gitlab.com/saltstack-formulas/infrastructure/inspec
-  revision: 2b56b68db2a758041b9df5b2e4bdc3c6700558ea
+  revision: 6bedc829b7fcec035311d8c6086db5d59414428c
   branch: ssf
   specs:
-    inspec (5.17.4)
+    inspec (5.17.9)
       cookstyle
       faraday_middleware (>= 0.12.2, < 1.1)
-      inspec-core (= 5.17.4)
+      inspec-core (= 5.17.9)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -14,7 +14,7 @@ GIT
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.17.4)
+    inspec-core (5.17.9)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.594.0)
+    aws-partitions (1.596.0)
     aws-sdk-alexaforbusiness (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -226,7 +226,7 @@ GEM
     aws-sdk-redshift (1.82.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-route53 (1.62.0)
+    aws-sdk-route53 (1.63.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53domains (1.40.0)
@@ -380,8 +380,8 @@ GEM
     inifile (3.0.0)
     jmespath (1.6.1)
     json (2.6.2)
-    jwt (2.3.0)
-    kitchen-inspec (2.5.2)
+    jwt (2.4.0)
+    kitchen-inspec (2.6.0)
       hashie (>= 3.4, <= 5.0)
       inspec (>= 2.2.64, < 6.0)
       test-kitchen (>= 2.7, < 4)
@@ -405,7 +405,7 @@ GEM
     minitest (5.15.0)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-install (3.12.16)
+    mixlib-install (3.12.19)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -425,7 +425,7 @@ GEM
       faraday-cookie_jar (~> 0.0.6)
       ms_rest (~> 0.7.6)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)


### PR DESCRIPTION
Test using latest `master` branch images:

* https://github.com/myii/salt/commit/6a9da114ec9260ffad66065919b7f76b421cf176
  - Includes one extra commit to avoid images being built as `3005`.

Test results:

* https://saltstack-formulas.zulipchat.com/#narrow/stream/239693-CI/topic/myii-ci.2F2022-W23a