### PR TITLE
feat(pre-commit): update configuration inc. for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,18 @@
 ---
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+ci:
+  autofix_commit_msg: |
+    ci(pre-commit.ci): apply auto fixes from pre-commit.com hooks
+
+    For more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: ''
+  autoupdate_commit_msg: |
+    ci(pre-commit.ci): perform `pre-commit` autoupdate
+  autoupdate_schedule: weekly
+  skip: []
+  submodules: false
 default_stages: [commit]
 repos:
   - repo: https://github.com/dafyddj/commitlint-pre-commit-hook

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         additional_dependencies: ['@commitlint/config-conventional@8.3.4']
         always_run: true
   - repo: https://github.com/rubocop-hq/rubocop
-    rev: v1.25.1
+    rev: v1.30.1
     hooks:
       - id: rubocop
         name: Check Ruby files with rubocop

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,8 +64,8 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "chore(gemfile.lock): update to latest gem versions (2022-W23) [skip ci]"
-            body: '* Automated using https://github.com/myii/ssf-formula/pull/449'
+            title: "ci: update '`'pre-commit'`' configuration [skip ci]"
+            body: '* Automated using https://github.com/myii/ssf-formula/pull/450'
             # yamllint enable rule:line-length rule:quoted-strings
           github:
             owner: 'saltstack-formulas'

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -366,7 +366,6 @@ ssf:
     - [freebsd      ,   12.3 ,   3004.0,      3]  # fbsd-12.3-3004.0-py3
     ### `openbsd`
     - [openbsd      ,    7.0 ,   3003.3,      3]  # obsd-07.0-3003.3-py3
-    - [openbsd      ,    6.9 ,   3002.6,      3]  # obsd-06.9-3002.6-py3
     ### `windows`
     - [windows      ,   10   ,   latest,      3]  # wind-10.0-latest-py3
     - [windows      ,    8.1 ,   latest,      3]  # wind-08.1-latest-py3
@@ -383,6 +382,7 @@ ssf:
     - [freebsd      ,   12.2 ,   3002.6,      3]  # fbsd-12.2-3002.6-py3
     - [freebsd      ,   11.4 ,   3002.6,      3]  # fbsd-11.4-3002.6-py3
     ### `openbsd`
+    - [openbsd      ,    6.9 ,   3002.6,      3]  # obsd-06.9-3002.6-py3
     - [openbsd      ,    6.8 ,   3001.1,      3]  # obsd-06.8-3001.1-py3
   saltimages_proposed:
     ### Already available but not using across the Formulas' org until released
@@ -401,7 +401,6 @@ ssf:
     # # Not available at the current time
     # - [fedora       ,   36   ,   tiamat,      3]  # fedo-36.0-tiamat-py3
     # - [fedora       ,   35   ,   tiamat,      3]  # fedo-35.0-tiamat-py3
-    # - [fedora       ,   34   ,   tiamat,      3]  # fedo-34.0-tiamat-py3
     # - [opensuse/leap,   15.3 ,   tiamat,      3]  # opsu-15.3-tiamat-py3
     # - [opensuse/tmbl,  latest,   tiamat,      3]  # opsu-tmbl-tiamat-py3
     - [amazonlinux  ,    2   ,   tiamat,      3]  # amaz-02.0-tiamat-py3
@@ -421,7 +420,6 @@ ssf:
     - [centos       ,    7   ,   master,      3]  # cent-07.0-master-py3
     - [fedora       ,   36   ,   master,      3]  # fedo-36.0-master-py3
     - [fedora       ,   35   ,   master,      3]  # fedo-35.0-master-py3
-    - [fedora       ,   34   ,   master,      3]  # fedo-34.0-master-py3
     - [opensuse/leap,   15.3 ,   master,      3]  # opsu-15.3-master-py3
     - [opensuse/tmbl,  latest,   master,      3]  # opsu-tmbl-master-py3
     - [amazonlinux  ,    2   ,   master,      3]  # amaz-02.0-master-py3
@@ -444,7 +442,6 @@ ssf:
     - [centos       ,    7   ,   3004.1,      3]  # cent-07.0-3004.1-py3
     - [fedora       ,   36   ,   3004.1,      3]  # fedo-36.0-3004.1-py3
     - [fedora       ,   35   ,   3004.1,      3]  # fedo-35.0-3004.1-py3
-    - [fedora       ,   34   ,   3004.1,      3]  # fedo-34.0-3004.1-py3
     - [amazonlinux  ,    2   ,   3004.1,      3]  # amaz-02.0-3004.1-py3
     - [oraclelinux  ,    8   ,   3004.1,      3]  # orac-08.0-3004.1-py3
     - [oraclelinux  ,    7   ,   3004.1,      3]  # orac-07.0-3004.1-py3
@@ -469,16 +466,6 @@ ssf:
     - [oraclelinux  ,    7   ,   3003.4,      3]  # orac-07.0-3003.4-py3
     - [almalinux    ,    8   ,   3003.4,      3]  # alma-08.0-3003.4-py3
 
-    ### `3002.8-py3`
-    - [debian       ,   10   ,   3002.8,      3]  # debi-10.0-3002.8-py3
-    - [debian       ,    9   ,   3002.8,      3]  # debi-09.0-3002.8-py3
-    - [ubuntu       ,   20.04,   3002.8,      3]  # ubun-20.0-3002.8-py3
-    - [ubuntu       ,   18.04,   3002.8,      3]  # ubun-18.0-3002.8-py3
-    - [centos       ,    7   ,   3002.8,      3]  # cent-07.0-3002.8-py3
-    - [amazonlinux  ,    2   ,   3002.8,      3]  # amaz-02.0-3002.8-py3
-    - [oraclelinux  ,    8   ,   3002.8,      3]  # orac-08.0-3002.8-py3
-    - [oraclelinux  ,    7   ,   3002.8,      3]  # orac-07.0-3002.8-py3
-
   # saltimages_deprecated_stable_by_git:
   #   ### These aren't deprecated per se, since they are the latest `stable` images
   #   ### available; however, a latest version `git`-based image is available so using
@@ -490,17 +477,21 @@ ssf:
     ### `tiamat-py3`
     - [ubuntu       ,   16.04,   tiamat,      3]  # ubun-16.0-tiamat-py3
     - [centos       ,    8   ,   tiamat,      3]  # cent-08.0-tiamat-py3
+    # - [fedora       ,   34   ,   tiamat,      3]  # fedo-34.0-tiamat-py3
     # - [fedora       ,   33   ,   tiamat,      3]  # fedo-33.0-tiamat-py3
     # - [opensuse/leap,   15.2 ,   tiamat,      3]  # opsu-15.2-tiamat-py3
 
     ### `master-py3`
     - [ubuntu       ,   16.04,   master,      3]  # ubun-16.0-master-py3
     - [centos       ,    8   ,   master,      3]  # cent-08.0-master-py3
+    - [fedora       ,   34   ,   master,      3]  # fedo-34.0-master-py3
     - [fedora       ,   33   ,   master,      3]  # fedo-33.0-master-py3
     - [fedora       ,   32   ,   master,      3]  # fedo-32.0-master-py3
     - [fedora       ,   31   ,   master,      3]  # fedo-31.0-master-py3
     - [opensuse/leap,   15.2 ,   master,      3]  # opsu-15.2-master-py3
 
+    ### `3004.1-py3`
+    - [fedora       ,   34   ,   3004.1,      3]  # fedo-34.0-3004.1-py3
     ### `3004.0-py3`
     - [debian       ,   11   ,   3004.0,      3]  # debi-11.0-3004.0-py3
     - [debian       ,   10   ,   3004.0,      3]  # debi-10.0-3004.0-py3
@@ -609,6 +600,15 @@ ssf:
     - [gentoo/stage3, systemd,   3003.0,      3]  # gent-sysd-3003.0-py3
     - [almalinux    ,    8   ,   3003.0,      3]  # alma-08.0-3003.0-py3
 
+    ### `3002.8-py3`
+    - [debian       ,   10   ,   3002.8,      3]  # debi-10.0-3002.8-py3
+    - [debian       ,    9   ,   3002.8,      3]  # debi-09.0-3002.8-py3
+    - [ubuntu       ,   20.04,   3002.8,      3]  # ubun-20.0-3002.8-py3
+    - [ubuntu       ,   18.04,   3002.8,      3]  # ubun-18.0-3002.8-py3
+    - [centos       ,    7   ,   3002.8,      3]  # cent-07.0-3002.8-py3
+    - [amazonlinux  ,    2   ,   3002.8,      3]  # amaz-02.0-3002.8-py3
+    - [oraclelinux  ,    8   ,   3002.8,      3]  # orac-08.0-3002.8-py3
+    - [oraclelinux  ,    7   ,   3002.8,      3]  # orac-07.0-3002.8-py3
     ### `3002.7-py3`
     - [debian       ,   11   ,   3002.7,      3]  # debi-11.0-3002.7-py3
     - [debian       ,   10   ,   3002.7,      3]  # debi-10.0-3002.7-py3

--- a/ssf/defaults.yaml
+++ b/ssf/defaults.yaml
@@ -64,7 +64,7 @@ ssf_node_anchors:
             upstream: 'upstream'
           commit:
             # yamllint disable rule:line-length rule:quoted-strings
-            title: "ci: update '`'pre-commit'`' configuration [skip ci]"
+            title: "ci: update '`'pre-commit'`' configuration inc. for pre-commit.ci [skip ci]"
             body: '* Automated using https://github.com/myii/ssf-formula/pull/450'
             # yamllint enable rule:line-length rule:quoted-strings
           github:

--- a/ssf/files/default/.pre-commit-config.yaml
+++ b/ssf/files/default/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         always_run: true
   {%- if travis.use_single_job_for_linters %}
   - repo: https://github.com/rubocop-hq/rubocop
-    rev: v1.25.1
+    rev: v1.30.1
     hooks:
       - id: rubocop
         name: Check Ruby files with rubocop

--- a/ssf/files/default/.pre-commit-config.yaml
+++ b/ssf/files/default/.pre-commit-config.yaml
@@ -3,6 +3,18 @@
 ---
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+ci:
+  autofix_commit_msg: |
+    ci(pre-commit.ci): apply auto fixes from pre-commit.com hooks
+
+    For more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: ''
+  autoupdate_commit_msg: |
+    ci(pre-commit.ci): perform `pre-commit` autoupdate
+  autoupdate_schedule: {{ 'weekly' if semrel_formula == 'ssf' else 'quarterly' }}
+  skip: []
+  submodules: false
 default_stages: [commit]
 repos:
   - repo: https://github.com/dafyddj/commitlint-pre-commit-hook

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -396,6 +396,7 @@ ssf_node_anchors:
       # in order to avoid security warnings
       semrel_files_mainly_gemfiles_only: &semrel_files_mainly_gemfiles_only
         .github/workflows/commitlint.yml: *file__--github__workflows__commitlint--yml
+        .pre-commit-config.yaml: *file__--pre-commit-config--yaml
         CODEOWNERS: *file__CODEOWNERS
         Gemfile: *file__Gemfile
         Gemfile.lock: *file__Gemfile--lock

--- a/ssf/formulas.yaml
+++ b/ssf/formulas.yaml
@@ -933,8 +933,7 @@ ssf:
           # # - [ubuntu       ,    0   ,   master,      0,         default]
           # # - [centos       ,    0   ,   master,      0,         default]
           - [centos       ,    7   ,   master,      0,         default]
-          # - [fedora       ,    0   ,   master,      0,         default]
-          - [fedora       ,   34   ,   master,      0,         default]
+          # # - [fedora       ,    0   ,   master,      0,         default]
           - [opensuse/leap,    0   ,   master,      0,         default]
           # # - [opensuse/tmbl,    0   ,   master,      0,         default]
           # # - [amazonlinux  ,    0   ,   master,      0,         default]
@@ -4448,8 +4447,6 @@ ssf:
                   - v3004-py3
               - 'G@saltversioninfo:0:3003 and G@pythonversion:0:3':
                   - v3003-py3
-              - 'G@saltversioninfo:0:3002 and G@pythonversion:0:3':
-                  - v3002-py3
         map_jinja:
           verification:
             import: ['salt_settings', 'formulas_settings']
@@ -4457,7 +4454,7 @@ ssf:
           # [os           ,  os_ver, salt_ver, py_ver,    inspec_suite]
           - [debian       ,   11   ,   3004.1,      3,         default]
           - [debian       ,   10   ,   3003.4,      3,         default]
-          - [debian       ,    9   ,   3002.8,      3,         default]
+          - [debian       ,    9   ,   3003.4,      3,         default]
           - [ubuntu       ,   22.04,   3004.1,      3,         default]
           - [ubuntu       ,   20.04,   3004.1,      3,         default]
           - [ubuntu       ,   18.04,   3003.4,      3,         default]
@@ -4467,7 +4464,6 @@ ssf:
           # # `fedora` only installs `3004.X`
           - [fedora       ,   36   ,   3004.1,      3,         default]
           - [fedora       ,   35   ,   3004.1,      3,         default]
-          - [fedora       ,   34   ,   3004.1,      3,         default]
           # # `opensuse/*` only installs `3004.X`
           - [opensuse/leap,   15.3 ,   3004.0,      3,         default]
           - [opensuse/tmbl,  latest,   3004.0,      3,         default]
@@ -4484,7 +4480,6 @@ ssf:
           # # platforms above
           - [freebsd      ,    0   ,   3004.0,      3,         default]
           - [openbsd      ,    7.0 ,   3003.3,      3,         default]
-          - [openbsd      ,    6.9 ,   3002.6,      3,         default]
           - [windows      ,    0   ,   latest,      3,         default]
           - [macos        ,    0   ,   latest,      3,         default]
         testing_freebsd:


### PR DESCRIPTION
Also includes:

#### feat(formulas): add `pre-commit` config to basic management formulas

Now required after enabling pre-commit.ci across the org.

#### feat(pre-commit): update `rubocop` linter version

* github.com/rubocop-hq/rubocop: v1.25.1 → v1.30.1
  - https://github.com/rubocop-hq/rubocop/compare/v1.25.1...v1.30.1

#### feat(saltimages): update with latest changes from `salt-image-builder`

* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/merge_requests/145